### PR TITLE
[FIX] add completions capability to server configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,8 @@ class NotebookLMMCPServer {
           tools: {},
           resources: {},
           resourceTemplates: {},
-          prompts: {}, // Required for completion/complete support in some clients
+          prompts: {},
+          completions: {}, // Required for completion/complete support
           logging: {},
         },
       }


### PR DESCRIPTION
Fixes a startup crash on Claude Desktop (tested on macOS) where the server would fail with: 'Error: Server does not support completions (required for completion/complete)'

The ResourceHandlers class registers a CompleteRequestSchema handler (src/resources/resource-handlers.ts:215) for notebook ID autocompletion in resource templates, but the server capabilities declaration did not include completions support.

The MCP SDK requires capability declaration before registering handlers for that capability type, causing the server to crash on initialization.

Changes:
- Added completions: {} to server capabilities in src/index.ts

This is a non-breaking change that enables existing autocomplete functionality to work properly. The completion handler provides autocomplete suggestions for notebook IDs when using resource templates like notebooklm://library/{id}.

Tested:
- Server starts successfully without errors
- MCP protocol initialization works
- All existing functionality preserved