### PR TITLE
docs: add OpenCode installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ code --add-mcp '{"name":"notebooklm","command":"npx","args":["notebooklm-mcp@lat
 </details>
 
 <details>
+<summary>OpenCode</summary>
+
+Add to `~/.config/opencode/opencode.json`:
+```json
+{
+  "mcp": {
+    "notebooklm": {
+      "type": "local",
+      "command": ["npx", "-y", "notebooklm-mcp@latest"],
+      "enabled": true
+    }
+  }
+}
+```
+</details>
+
+<details>
 <summary>Other MCP clients</summary>
 
 **Generic MCP config:**


### PR DESCRIPTION
## Summary
- Added OpenCode installation instructions to README.md

## Changes
- **OpenCode Installation**: Added new section in README.md showing how to configure notebooklm-mcp in `~/.config/opencode/opencode.json` with proper JSON structure including type, command array, and enabled flag

This follows the pattern of other MCP client installation sections in the README.