### PR TITLE
feat: add studio artifact generation (audio, video, slides, reports, quizzes, etc.)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# NotebookLM MCP Server (Fork with Studio Artifacts)
+
+## What This Fork Adds
+
+This fork of [PleasePrompto/notebooklm-mcp](https://github.com/PleasePrompto/notebooklm-mcp) adds **studio artifact generation** -- the ability to create NotebookLM's rich media outputs programmatically via MCP tools.
+
+### New Tools
+
+| Tool | Description |
+|------|-------------|
+| `studio_create` | Unified tool to create any studio artifact type |
+| `studio_status` | Check generation status and get download URLs |
+| `studio_delete` | Delete an artifact (irreversible) |
+
+### Supported Artifact Types
+
+| Type | Options |
+|------|---------|
+| **Audio Overview** | Formats: deep_dive, brief, critique, debate. Lengths: short, default, long |
+| **Video Overview** | Formats: explainer, brief, cinematic. Styles: classic, whiteboard, kawaii, anime, watercolor, retro_print, heritage, paper_craft |
+| **Infographic** | Orientations: landscape, portrait, square. Styles: sketch_note, professional, bento_grid, editorial, instructional, bricks, clay, anime, kawaii, scientific |
+| **Slide Deck** | Formats: detailed_deck, presenter_slides. Lengths: short, default |
+| **Report** | Formats: Briefing Doc, Study Guide, Blog Post, Create Your Own |
+| **Quiz** | Difficulty: easy, medium, hard. Configurable question count |
+| **Flashcards** | Difficulty: easy, medium, hard |
+| **Mind Map** | Auto-generates and saves concept relationship visualization |
+| **Data Table** | Structured data extraction from sources |
+
+All types support `focus_prompt` for guiding generation and `language` for localization.
+
+## Architecture Decision: Direct RPC (not browser automation)
+
+Studio artifacts are created via **direct HTTP calls** to NotebookLM's internal `batchexecute` API, not by clicking through the UI. This is:
+
+- **Faster**: No browser rendering or DOM manipulation needed
+- **More reliable**: No CSS selectors to break when the UI changes
+- **Lighter**: Only needs cookies, not a running browser instance
+
+The implementation:
+1. Extracts Google auth cookies from the existing Patchright browser context
+2. Fetches a CSRF token from the NotebookLM page
+3. Makes POST requests to `/_/LabsTailwindUi/data/batchexecute` with reverse-engineered RPC payloads
+
+### Reference Implementation
+
+The RPC protocol and payload structures are ported from [jacob-bd/notebooklm-mcp-cli](https://github.com/jacob-bd/notebooklm-mcp-cli) (Python, MIT license). Key files studied:
+- `core/base.py` -- batchexecute protocol (~300 lines)
+- `core/studio.py` -- studio creation methods (~1,300 lines)
+- `core/constants.py` -- RPC IDs and enum codes
+
+## New Source Files
+
+```
+src/api/
+  constants.ts       -- RPC IDs, studio type codes, enum mappings
+  rpc-client.ts      -- batchexecute HTTP client (cookie auth, CSRF, retry)
+  studio-client.ts   -- Studio artifact creation/polling/deletion methods
+src/tools/
+  definitions/
+    studio.ts        -- MCP tool schemas for studio_create, studio_status, studio_delete
+  studio-handlers.ts -- Bridges MCP tools to StudioClient (cookie extraction, param mapping)
+```
+
+## How to Test
+
+```bash
+# Build
+bun install && bun run build
+
+# Test via MCP (add to Claude's MCP config)
+# The server registers studio tools alongside existing Q&A tools
+
+# Example: Create an audio overview
+# Use studio_create with:
+#   notebook_url: "https://notebooklm.google.com/notebook/<id>"
+#   artifact_type: "audio"
+#   audio_format: "deep_dive"
+
+# Check status
+# Use studio_status with the same notebook_url
+
+# The auth is shared with the existing browser session
+# Run setup_auth first if not already authenticated
+```
+
+## What Works
+
+- All 9 artifact types are implemented with full parameter support
+- Cookie extraction from Patchright browser context
+- CSRF token auto-extraction and refresh on expiry
+- Auth retry on 401/403 errors
+- Status polling with artifact URL extraction
+- Artifact deletion
+
+## Known Limitations
+
+- Artifact generation is async -- you must poll studio_status to check completion
+- Audio/video generation can take 1-5 minutes
+- The batchexecute API is undocumented and may change without notice
+- Download URLs are extracted from status response but download itself is not implemented
+- Mind map generation is a two-step process (generate JSON + save)
+
+## Upstream
+
+- **Repo**: [PleasePrompto/notebooklm-mcp](https://github.com/PleasePrompto/notebooklm-mcp)
+- **Version**: v1.2.1
+- **Tools**: 16 (Q&A, notebook library, session management, auth)
+
+## Development
+
+```bash
+bun install          # Install dependencies
+bun run build        # Build (tsc)
+bun run dev          # Dev mode with watch
+```

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -1,0 +1,236 @@
+/**
+ * Constants for NotebookLM internal API.
+ *
+ * Ported from jacob-bd/notebooklm-mcp-cli (MIT license).
+ * These are reverse-engineered RPC IDs and enum codes used by
+ * NotebookLM's batchexecute endpoint.
+ */
+
+// =========================================================================
+// RPC IDs
+// =========================================================================
+
+export const RPC_IDS = {
+  // Notebook operations
+  LIST_NOTEBOOKS: "wXbhsf",
+  GET_NOTEBOOK: "rLM1Ne",
+  CREATE_NOTEBOOK: "CCqFvf",
+  RENAME_NOTEBOOK: "s0tc2d",
+  DELETE_NOTEBOOK: "WWINqb",
+
+  // Source operations
+  ADD_SOURCE: "izAoDd",
+  GET_SOURCE: "hizoJc",
+  DELETE_SOURCE: "tGMBJ",
+
+  // Studio content RPCs
+  CREATE_STUDIO: "R7cb6c",
+  POLL_STUDIO: "gArtLc",
+  DELETE_STUDIO: "V5N4be",
+  RENAME_ARTIFACT: "rc3d8d",
+  GET_INTERACTIVE_HTML: "v9rmvd",
+  REVISE_SLIDE_DECK: "KmcKPe",
+
+  // Mind map RPCs
+  GENERATE_MIND_MAP: "yyryJe",
+  SAVE_MIND_MAP: "CYK0Xb",
+  LIST_MIND_MAPS: "cFji9",
+  DELETE_MIND_MAP: "AH0mwd",
+
+  // Misc
+  GET_CONVERSATIONS: "hPTbtc",
+  GET_SUMMARY: "VfAZjd",
+  GET_SOURCE_GUIDE: "tr032e",
+} as const;
+
+// =========================================================================
+// Studio Types
+// =========================================================================
+
+export const STUDIO_TYPE = {
+  AUDIO: 1,
+  REPORT: 2,
+  VIDEO: 3,
+  FLASHCARDS: 4, // Also Quiz (distinguished by inner format code)
+  INFOGRAPHIC: 7,
+  SLIDE_DECK: 8,
+  DATA_TABLE: 9,
+} as const;
+
+// =========================================================================
+// Audio
+// =========================================================================
+
+export const AUDIO_FORMAT = {
+  DEEP_DIVE: 1,
+  BRIEF: 2,
+  CRITIQUE: 3,
+  DEBATE: 4,
+} as const;
+
+export const AUDIO_LENGTH = {
+  SHORT: 1,
+  DEFAULT: 2,
+  LONG: 3,
+} as const;
+
+// =========================================================================
+// Video
+// =========================================================================
+
+export const VIDEO_FORMAT = {
+  EXPLAINER: 1,
+  BRIEF: 2,
+  CINEMATIC: 3,
+} as const;
+
+export const VIDEO_STYLE = {
+  AUTO_SELECT: 1,
+  CUSTOM: 2,
+  CLASSIC: 3,
+  WHITEBOARD: 4,
+  KAWAII: 5,
+  ANIME: 6,
+  WATERCOLOR: 7,
+  RETRO_PRINT: 8,
+  HERITAGE: 9,
+  PAPER_CRAFT: 10,
+} as const;
+
+// =========================================================================
+// Infographic
+// =========================================================================
+
+export const INFOGRAPHIC_ORIENTATION = {
+  LANDSCAPE: 1,
+  PORTRAIT: 2,
+  SQUARE: 3,
+} as const;
+
+export const INFOGRAPHIC_DETAIL = {
+  CONCISE: 1,
+  STANDARD: 2,
+  DETAILED: 3,
+} as const;
+
+export const INFOGRAPHIC_STYLE = {
+  AUTO_SELECT: 1,
+  SKETCH_NOTE: 2,
+  PROFESSIONAL: 3,
+  BENTO_GRID: 4,
+  EDITORIAL: 5,
+  INSTRUCTIONAL: 6,
+  BRICKS: 7,
+  CLAY: 8,
+  ANIME: 9,
+  KAWAII: 10,
+  SCIENTIFIC: 11,
+} as const;
+
+// =========================================================================
+// Slide Deck
+// =========================================================================
+
+export const SLIDE_DECK_FORMAT = {
+  DETAILED: 1,
+  PRESENTER: 2,
+} as const;
+
+export const SLIDE_DECK_LENGTH = {
+  SHORT: 1,
+  DEFAULT: 3,
+} as const;
+
+// =========================================================================
+// Flashcards / Quiz
+// =========================================================================
+
+export const FLASHCARD_DIFFICULTY = {
+  EASY: 1,
+  MEDIUM: 2,
+  HARD: 3,
+} as const;
+
+export const FLASHCARD_COUNT_DEFAULT = 2;
+
+// =========================================================================
+// Report
+// =========================================================================
+
+export const REPORT_FORMAT = {
+  BRIEFING_DOC: "Briefing Doc",
+  STUDY_GUIDE: "Study Guide",
+  BLOG_POST: "Blog Post",
+  CUSTOM: "Create Your Own",
+} as const;
+
+// =========================================================================
+// Human-readable name mappings (code -> name)
+// =========================================================================
+
+export function getAudioFormatName(code: number): string {
+  const map: Record<number, string> = { 1: "deep_dive", 2: "brief", 3: "critique", 4: "debate" };
+  return map[code] ?? "unknown";
+}
+
+export function getAudioLengthName(code: number): string {
+  const map: Record<number, string> = { 1: "short", 2: "default", 3: "long" };
+  return map[code] ?? "unknown";
+}
+
+export function getVideoFormatName(code: number): string {
+  const map: Record<number, string> = { 1: "explainer", 2: "brief", 3: "cinematic" };
+  return map[code] ?? "unknown";
+}
+
+export function getVideoStyleName(code: number | null | undefined): string {
+  if (code == null) return "unknown";
+  const map: Record<number, string> = {
+    1: "auto_select", 2: "custom", 3: "classic", 4: "whiteboard",
+    5: "kawaii", 6: "anime", 7: "watercolor", 8: "retro_print",
+    9: "heritage", 10: "paper_craft",
+  };
+  return map[code] ?? "unknown";
+}
+
+export function getInfographicOrientationName(code: number): string {
+  const map: Record<number, string> = { 1: "landscape", 2: "portrait", 3: "square" };
+  return map[code] ?? "unknown";
+}
+
+export function getInfographicDetailName(code: number): string {
+  const map: Record<number, string> = { 1: "concise", 2: "standard", 3: "detailed" };
+  return map[code] ?? "unknown";
+}
+
+export function getInfographicStyleName(code: number): string {
+  const map: Record<number, string> = {
+    1: "auto_select", 2: "sketch_note", 3: "professional", 4: "bento_grid",
+    5: "editorial", 6: "instructional", 7: "bricks", 8: "clay",
+    9: "anime", 10: "kawaii", 11: "scientific",
+  };
+  return map[code] ?? "unknown";
+}
+
+export function getSlideDeckFormatName(code: number): string {
+  const map: Record<number, string> = { 1: "detailed_deck", 2: "presenter_slides" };
+  return map[code] ?? "unknown";
+}
+
+export function getSlideDeckLengthName(code: number): string {
+  const map: Record<number, string> = { 1: "short", 3: "default" };
+  return map[code] ?? "unknown";
+}
+
+export function getFlashcardDifficultyName(code: number): string {
+  const map: Record<number, string> = { 1: "easy", 2: "medium", 3: "hard" };
+  return map[code] ?? "unknown";
+}
+
+export function getStudioTypeName(code: number): string {
+  const map: Record<number, string> = {
+    1: "audio", 2: "report", 3: "video", 4: "flashcards",
+    7: "infographic", 8: "slide_deck", 9: "data_table",
+  };
+  return map[code] ?? "unknown";
+}

--- a/src/api/rpc-client.ts
+++ b/src/api/rpc-client.ts
@@ -1,0 +1,391 @@
+/**
+ * RPC Client for NotebookLM's internal batchexecute API.
+ *
+ * Ported from jacob-bd/notebooklm-mcp-cli base.py (MIT license).
+ *
+ * Uses Patchright's page context to make fetch() calls from within the
+ * browser, which ensures cookies are sent correctly with proper domain
+ * matching. This avoids the CookieMismatch issue that occurs when sending
+ * cookies via a flat Cookie header from Node.js.
+ */
+
+import type { Page, BrowserContext } from "patchright";
+import { log } from "../utils/logger.js";
+
+const BASE_URL = "https://notebooklm.google.com";
+const BATCHEXECUTE_URL = `${BASE_URL}/_/LabsTailwindUi/data/batchexecute`;
+const BL_FALLBACK = "boq_labs-tailwind-frontend_20260108.06_p0";
+
+/**
+ * Cookie data (kept for API compatibility, but not used for auth anymore).
+ */
+export interface CookieData {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+}
+
+/**
+ * Authentication error from NotebookLM API.
+ */
+export class AuthenticationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthenticationError";
+  }
+}
+
+/**
+ * RPC error from NotebookLM API.
+ */
+export class RPCError extends Error {
+  public readonly errorCode: number;
+  public readonly detailType: string;
+
+  constructor(message: string, errorCode: number, detailType: string = "") {
+    super(message);
+    this.name = "RPCError";
+    this.errorCode = errorCode;
+    this.detailType = detailType;
+  }
+}
+
+/**
+ * Internal interface for the response from browser-side fetch.
+ */
+interface BrowserFetchResult {
+  ok: boolean;
+  status: number;
+  url: string;
+  text: string;
+}
+
+/**
+ * Direct HTTP client for NotebookLM's batchexecute API.
+ *
+ * Uses a Patchright Page to make requests from within the browser context,
+ * ensuring proper cookie domain matching.
+ */
+export class RPCClient {
+  private page: Page | null = null;
+  private context: BrowserContext | null = null;
+  private csrfToken: string = "";
+  private sessionId: string = "";
+  private buildLabel: string = "";
+  private initialized: boolean = false;
+
+  /**
+   * Set the browser page to use for API calls.
+   * The page must be on a notebooklm.google.com origin.
+   */
+  setPage(page: Page): void {
+    this.page = page;
+    this.initialized = false;
+  }
+
+  /**
+   * Set the browser context (used to create a page if none provided).
+   */
+  setContext(context: BrowserContext): void {
+    this.context = context;
+    this.initialized = false;
+  }
+
+  /**
+   * Initialize by extracting CSRF token from the current page.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized && this.csrfToken) return;
+
+    if (!this.page && this.context) {
+      // Create a new page and navigate to NotebookLM
+      this.page = await this.context.newPage();
+      await this.page.goto(`${BASE_URL}/`, {
+        waitUntil: "domcontentloaded",
+        timeout: 30000,
+      });
+      // Wait for page to load
+      await this.page.waitForTimeout(2000);
+    }
+
+    if (!this.page) {
+      throw new Error("No page or context available for RPC client");
+    }
+
+    log.info("  [RPC] Extracting auth tokens from browser page...");
+
+    const currentUrl = this.page.url();
+    if (!currentUrl.includes("notebooklm.google.com")) {
+      // Navigate to NotebookLM
+      await this.page.goto(`${BASE_URL}/`, {
+        waitUntil: "domcontentloaded",
+        timeout: 30000,
+      });
+      await this.page.waitForTimeout(2000);
+
+      const newUrl = this.page.url();
+      if (newUrl.includes("accounts.google.com")) {
+        throw new AuthenticationError(
+          "Authentication expired. Please re-authenticate using setup_auth or re_auth."
+        );
+      }
+    }
+
+    // Extract tokens from page HTML via page.evaluate (runs in browser context)
+    const tokens = await this.page.evaluate((): { csrf: string; sid: string; bl: string } => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const doc = globalThis as any;
+      const html: string = doc.document.documentElement.outerHTML;
+      const csrfMatch = html.match(/"SNlM0e":"([^"]+)"/);
+      const sidMatch = html.match(/"FdrFJe":"([^"]+)"/);
+      const blMatch = html.match(/"cfb2h":"([^"]+)"/);
+      return {
+        csrf: csrfMatch ? csrfMatch[1] : "",
+        sid: sidMatch ? sidMatch[1] : "",
+        bl: blMatch ? blMatch[1] : "",
+      };
+    });
+
+    if (!tokens.csrf) {
+      throw new Error("Could not extract CSRF token from NotebookLM page");
+    }
+
+    this.csrfToken = tokens.csrf;
+    this.sessionId = tokens.sid;
+    this.buildLabel = tokens.bl;
+    this.initialized = true;
+
+    log.info(`  [RPC] Tokens extracted (csrf=${this.csrfToken.slice(0, 10)}...)`);
+  }
+
+  /**
+   * Build the batchexecute request body.
+   */
+  private buildRequestBody(rpcId: string, params: unknown): string {
+    const paramsJson = JSON.stringify(params);
+    const fReq = [[[rpcId, paramsJson, null, "generic"]]];
+    const fReqJson = JSON.stringify(fReq);
+
+    const parts = [`f.req=${encodeURIComponent(fReqJson)}`];
+    if (this.csrfToken) {
+      parts.push(`at=${encodeURIComponent(this.csrfToken)}`);
+    }
+
+    return parts.join("&") + "&";
+  }
+
+  /**
+   * Build the batchexecute URL with query parameters.
+   */
+  private buildUrl(rpcId: string, sourcePath: string = "/"): string {
+    const params = new URLSearchParams({
+      rpcids: rpcId,
+      "source-path": sourcePath,
+      bl: this.buildLabel || BL_FALLBACK,
+      hl: "en",
+      rt: "c",
+    });
+
+    if (this.sessionId) {
+      params.set("f.sid", this.sessionId);
+    }
+
+    return `${BATCHEXECUTE_URL}?${params.toString()}`;
+  }
+
+  /**
+   * Parse the batchexecute response.
+   */
+  private parseResponse(responseText: string): unknown[] {
+    let text = responseText;
+    if (text.startsWith(")]}'")) {
+      text = text.slice(4);
+    }
+
+    const lines = text.trim().split("\n");
+    const results: unknown[] = [];
+    let i = 0;
+
+    while (i < lines.length) {
+      const line = lines[i].trim();
+      if (!line) {
+        i++;
+        continue;
+      }
+
+      const byteCount = parseInt(line, 10);
+      if (!isNaN(byteCount)) {
+        i++;
+        if (i < lines.length) {
+          try {
+            const data = JSON.parse(lines[i]);
+            results.push(data);
+          } catch {
+            // Not valid JSON
+          }
+          i++;
+        }
+      } else {
+        try {
+          const data = JSON.parse(line);
+          results.push(data);
+        } catch {
+          // Not valid JSON
+        }
+        i++;
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Extract the result for a specific RPC ID from parsed response.
+   */
+  private extractRpcResult(parsedResponse: unknown[], rpcId: string): unknown {
+    for (const chunk of parsedResponse) {
+      if (!Array.isArray(chunk)) continue;
+
+      for (const item of chunk) {
+        if (!Array.isArray(item) || item.length < 3) continue;
+        if (item[0] !== "wrb.fr" || item[1] !== rpcId) continue;
+
+        // Check for error in item[5]
+        if (item.length > 5 && Array.isArray(item[5]) && item[5].length > 0) {
+          const errorCode = typeof item[5][0] === "number" ? item[5][0] : null;
+
+          if (errorCode !== null) {
+            if (errorCode === 16) {
+              throw new AuthenticationError("RPC Error 16: Authentication expired");
+            }
+
+            let detailType = "";
+            if (item[5].length > 2 && Array.isArray(item[5][2])) {
+              for (const detail of item[5][2]) {
+                if (Array.isArray(detail) && detail.length > 0 && typeof detail[0] === "string") {
+                  detailType = detail[0];
+                  break;
+                }
+              }
+            }
+
+            const grpcCodes: Record<number, string> = {
+              3: "INVALID_ARGUMENT",
+              5: "NOT_FOUND",
+              7: "PERMISSION_DENIED",
+              16: "UNAUTHENTICATED",
+            };
+            const friendlyType = detailType || grpcCodes[errorCode] || "unknown";
+
+            throw new RPCError(
+              `API error (code ${errorCode}): ${friendlyType}`,
+              errorCode,
+              detailType
+            );
+          }
+        }
+
+        const resultStr = item[2];
+        if (typeof resultStr === "string") {
+          try {
+            return JSON.parse(resultStr);
+          } catch {
+            return resultStr;
+          }
+        }
+        return resultStr;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Execute an RPC call using the browser page's fetch context.
+   */
+  async callRpc(
+    rpcId: string,
+    params: unknown,
+    path: string = "/",
+    timeout: number = 30000,
+    retried: boolean = false
+  ): Promise<unknown> {
+    await this.initialize();
+
+    if (!this.page) {
+      throw new Error("No browser page available for RPC calls");
+    }
+
+    const body = this.buildRequestBody(rpcId, params);
+    const url = this.buildUrl(rpcId, path);
+
+    try {
+      // Execute fetch from within the browser page context
+      // This ensures cookies are sent with proper domain matching
+      const result: BrowserFetchResult = await this.page.evaluate(
+        async ({ url, body, csrfToken, timeout }) => {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+          try {
+            const response = await fetch(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+                "X-Same-Domain": "1",
+                ...(csrfToken ? { "X-Goog-Csrf-Token": csrfToken } : {}),
+              },
+              body,
+              signal: controller.signal,
+              credentials: "include",
+            });
+
+            clearTimeout(timeoutId);
+
+            return {
+              ok: response.ok,
+              status: response.status,
+              url: response.url,
+              text: await response.text(),
+            };
+          } catch (error: any) {
+            clearTimeout(timeoutId);
+            throw new Error(error.message || String(error));
+          }
+        },
+        { url, body, csrfToken: this.csrfToken, timeout }
+      );
+
+      if (!result.ok) {
+        const isAuthError = [400, 401, 403].includes(result.status);
+        if (isAuthError && !retried) {
+          log.warning("  [RPC] Auth error, refreshing tokens and retrying...");
+          this.initialized = false;
+          return this.callRpc(rpcId, params, path, timeout, true);
+        }
+        throw new Error(`HTTP ${result.status}`);
+      }
+
+      const parsed = this.parseResponse(result.text);
+      return this.extractRpcResult(parsed, rpcId);
+    } catch (error) {
+      if (error instanceof AuthenticationError && !retried) {
+        log.warning("  [RPC] Authentication expired, refreshing tokens...");
+        this.initialized = false;
+        return this.callRpc(rpcId, params, path, timeout, true);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Close the RPC client's page if it was created internally.
+   */
+  async close(): Promise<void> {
+    // Don't close the page -- it may be shared with other code
+    this.page = null;
+    this.context = null;
+    this.initialized = false;
+  }
+}

--- a/src/api/studio-client.ts
+++ b/src/api/studio-client.ts
@@ -1,0 +1,1043 @@
+/**
+ * Studio Client for NotebookLM artifact generation.
+ *
+ * Ported from jacob-bd/notebooklm-mcp-cli studio.py (MIT license).
+ * Creates studio artifacts (audio, video, reports, quizzes, flashcards,
+ * infographics, slide decks, data tables, mind maps) via direct RPC calls.
+ */
+
+import type { Page, BrowserContext } from "patchright";
+import { RPCClient } from "./rpc-client.js";
+import {
+  RPC_IDS,
+  STUDIO_TYPE,
+  AUDIO_FORMAT,
+  AUDIO_LENGTH,
+  VIDEO_FORMAT,
+  VIDEO_STYLE,
+  INFOGRAPHIC_ORIENTATION,
+  INFOGRAPHIC_DETAIL,
+  INFOGRAPHIC_STYLE,
+  SLIDE_DECK_FORMAT,
+  SLIDE_DECK_LENGTH,
+  FLASHCARD_DIFFICULTY,
+  FLASHCARD_COUNT_DEFAULT,
+  getAudioFormatName,
+  getAudioLengthName,
+  getVideoFormatName,
+  getVideoStyleName,
+  getInfographicOrientationName,
+  getInfographicDetailName,
+  getInfographicStyleName,
+  getSlideDeckFormatName,
+  getSlideDeckLengthName,
+  getFlashcardDifficultyName,
+  getStudioTypeName,
+} from "./constants.js";
+import { log } from "../utils/logger.js";
+
+export interface StudioArtifact {
+  artifact_id: string | null;
+  notebook_id: string;
+  type: string;
+  status: string;
+  [key: string]: unknown;
+}
+
+export interface StudioStatusArtifact {
+  artifact_id: string;
+  title: string;
+  type: string;
+  status: string;
+  audio_url?: string | null;
+  video_url?: string | null;
+  infographic_url?: string | null;
+  slide_deck_url?: string | null;
+  report_content?: string | null;
+  flashcard_count?: number | null;
+  duration_seconds?: number | null;
+  custom_instructions?: string | null;
+  created_at?: string | null;
+}
+
+/**
+ * Extract notebook ID from a NotebookLM URL.
+ * URL format: https://notebooklm.google.com/notebook/<id>
+ */
+export function extractNotebookId(url: string): string {
+  const match = url.match(/notebook\/([a-f0-9-]+)/i);
+  if (!match) {
+    throw new Error(`Could not extract notebook ID from URL: ${url}`);
+  }
+  return match[1];
+}
+
+/**
+ * Normalize raw artifact status code to a stable label.
+ */
+function normalizeStudioStatus(artifactData: unknown[]): string {
+  if (!Array.isArray(artifactData) || artifactData.length <= 4) return "unknown";
+
+  const statusCode = artifactData[4];
+  if (statusCode === 1) return "in_progress";
+  if (statusCode === 3) return "completed";
+  if (statusCode === 4) return "failed";
+
+  // Audio status=2 with media URLs means completed
+  const typeCode = artifactData[2];
+  if (statusCode === 2 && typeCode === STUDIO_TYPE.AUDIO) {
+    if (audioHasMediaUrls(artifactData)) return "completed";
+  }
+
+  return "unknown";
+}
+
+function audioHasMediaUrls(artifactData: unknown[]): boolean {
+  if (artifactData.length <= 6) return false;
+  const audioOptions = artifactData[6];
+  if (!Array.isArray(audioOptions) || audioOptions.length <= 5) return false;
+  const mediaList = audioOptions[5];
+  if (!Array.isArray(mediaList)) return false;
+
+  return mediaList.some(
+    (item: unknown) =>
+      Array.isArray(item) &&
+      item.length > 0 &&
+      typeof item[0] === "string" &&
+      item[0].startsWith("http")
+  );
+}
+
+function extractAudioMediaUrl(artifactData: unknown[]): string | null {
+  if (artifactData.length <= 6) return null;
+  const audioOptions = artifactData[6];
+  if (!Array.isArray(audioOptions)) return null;
+
+  if (audioOptions.length > 5 && Array.isArray(audioOptions[5])) {
+    const mediaList = audioOptions[5];
+
+    // Prefer -dv download variant
+    for (const item of mediaList) {
+      if (
+        Array.isArray(item) &&
+        item.length > 2 &&
+        typeof item[0] === "string" &&
+        item[0].startsWith("http") &&
+        item[2] === "audio/mp4" &&
+        item[0].endsWith("-dv")
+      ) {
+        return item[0];
+      }
+    }
+
+    // Any audio/mp4 URL
+    for (const item of mediaList) {
+      if (
+        Array.isArray(item) &&
+        item.length > 2 &&
+        typeof item[0] === "string" &&
+        item[0].startsWith("http") &&
+        item[2] === "audio/mp4"
+      ) {
+        return item[0];
+      }
+    }
+
+    // First valid URL
+    for (const item of mediaList) {
+      if (
+        Array.isArray(item) &&
+        item.length > 0 &&
+        typeof item[0] === "string" &&
+        item[0].startsWith("http")
+      ) {
+        return item[0];
+      }
+    }
+  }
+
+  // Older payloads: direct URL at position 3
+  if (audioOptions.length > 3 && typeof audioOptions[3] === "string") {
+    return audioOptions[3];
+  }
+
+  return null;
+}
+
+/**
+ * Studio client that uses direct RPC calls to create NotebookLM artifacts.
+ */
+export class StudioClient {
+  private rpcClient: RPCClient;
+
+  constructor() {
+    this.rpcClient = new RPCClient();
+  }
+
+  /**
+   * Set the browser page for making authenticated API calls.
+   */
+  setPage(page: Page): void {
+    this.rpcClient.setPage(page);
+  }
+
+  /**
+   * Set the browser context (creates a page internally if needed).
+   */
+  setContext(context: BrowserContext): void {
+    this.rpcClient.setContext(context);
+  }
+
+  /**
+   * Get all source IDs from a notebook.
+   * Uses the GET_NOTEBOOK RPC with the correct parameter format.
+   */
+  async getSourceIds(notebookId: string): Promise<string[]> {
+    try {
+      // Correct params per Python reference: [notebook_id, None, [2], None, 0]
+      const result = await this.rpcClient.callRpc(
+        RPC_IDS.GET_NOTEBOOK,
+        [notebookId, null, [2], null, 0],
+        `/notebook/${notebookId}`
+      );
+
+      if (!result || !Array.isArray(result)) return [];
+
+      const sourceIds: string[] = [];
+
+      // Per Python reference: notebook_data[0][1] contains sources array
+      // Each source: [[id], title, metadata, ...]
+      const notebookData = Array.isArray(result[0]) ? result[0] : result;
+      const sourcesData = notebookData.length > 1 ? notebookData[1] : [];
+
+      if (Array.isArray(sourcesData)) {
+        for (const src of sourcesData) {
+          if (Array.isArray(src) && src.length >= 1) {
+            // Source ID is at src[0][0] (nested in array)
+            const idContainer = src[0];
+            if (Array.isArray(idContainer) && idContainer.length > 0 && typeof idContainer[0] === "string") {
+              sourceIds.push(idContainer[0]);
+            }
+          }
+        }
+      }
+
+      return sourceIds;
+    } catch (error) {
+      log.warning(`  [Studio] Could not get source IDs: ${error}`);
+      return [];
+    }
+  }
+
+  // =========================================================================
+  // Audio Overview
+  // =========================================================================
+
+  async createAudioOverview(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      format?: number;
+      length?: number;
+      language?: string;
+      focusPrompt?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      format = AUDIO_FORMAT.DEEP_DIVE,
+      length = AUDIO_LENGTH.DEFAULT,
+      language = "en",
+      focusPrompt = "",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+    const sourcesSimple = sourceIds.map((sid) => [sid]);
+
+    const audioOptions = [
+      null,
+      [focusPrompt, length, null, sourcesSimple, language, null, format],
+    ];
+
+    const params = [
+      [2],
+      notebookId,
+      [null, null, STUDIO_TYPE.AUDIO, sourcesNested, null, null, audioOptions],
+    ];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "audio",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        format: getAudioFormatName(format),
+        length: getAudioLengthName(length),
+        language,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Video Overview
+  // =========================================================================
+
+  async createVideoOverview(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      format?: number;
+      visualStyle?: number;
+      visualStylePrompt?: string;
+      language?: string;
+      focusPrompt?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      format = VIDEO_FORMAT.EXPLAINER,
+      visualStyle = VIDEO_STYLE.AUTO_SELECT,
+      visualStylePrompt = "",
+      language = "en",
+      focusPrompt = "",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+    const sourcesSimple = sourceIds.map((sid) => [sid]);
+
+    // Build inner options (cinematic format omits visual style)
+    const innerOptions: unknown[] = [sourcesSimple, language, focusPrompt, null, format];
+    if (format !== VIDEO_FORMAT.CINEMATIC) {
+      innerOptions.push(visualStyle);
+      if (visualStylePrompt) {
+        innerOptions.push(visualStylePrompt);
+      }
+    }
+
+    const videoOptions = [null, null, innerOptions];
+
+    const params = [
+      [2],
+      notebookId,
+      [null, null, STUDIO_TYPE.VIDEO, sourcesNested, null, null, null, null, videoOptions],
+    ];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "video",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        format: getVideoFormatName(format),
+        visual_style:
+          format !== VIDEO_FORMAT.CINEMATIC ? getVideoStyleName(visualStyle) : null,
+        visual_style_prompt: visualStylePrompt || null,
+        language,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Infographic
+  // =========================================================================
+
+  async createInfographic(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      orientation?: number;
+      detailLevel?: number;
+      visualStyle?: number;
+      language?: string;
+      focusPrompt?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      orientation = INFOGRAPHIC_ORIENTATION.LANDSCAPE,
+      detailLevel = INFOGRAPHIC_DETAIL.STANDARD,
+      visualStyle = INFOGRAPHIC_STYLE.AUTO_SELECT,
+      language = "en",
+      focusPrompt = "",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+
+    const infographicOptions = [
+      [focusPrompt || null, language, null, orientation, detailLevel, visualStyle],
+    ];
+
+    const content: unknown[] = [
+      null, null, STUDIO_TYPE.INFOGRAPHIC, sourcesNested,
+      null, null, null, null, null, null, null, null, null, null,
+      infographicOptions,
+    ];
+
+    const params = [[2], notebookId, content];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "infographic",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        orientation: getInfographicOrientationName(orientation),
+        detail_level: getInfographicDetailName(detailLevel),
+        visual_style: getInfographicStyleName(visualStyle),
+        language,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Slide Deck
+  // =========================================================================
+
+  async createSlideDeck(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      format?: number;
+      length?: number;
+      language?: string;
+      focusPrompt?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      format = SLIDE_DECK_FORMAT.DETAILED,
+      length = SLIDE_DECK_LENGTH.DEFAULT,
+      language = "en",
+      focusPrompt = "",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+
+    const slideDeckOptions = [[focusPrompt || null, language, format, length]];
+
+    const content: unknown[] = [
+      null, null, STUDIO_TYPE.SLIDE_DECK, sourcesNested,
+      null, null, null, null, null, null, null, null, null, null, null, null,
+      slideDeckOptions,
+    ];
+
+    const params = [[2], notebookId, content];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "slide_deck",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        format: getSlideDeckFormatName(format),
+        length: getSlideDeckLengthName(length),
+        language,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Report
+  // =========================================================================
+
+  async createReport(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      reportFormat?: string;
+      customPrompt?: string;
+      language?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      reportFormat = "Briefing Doc",
+      customPrompt = "",
+      language = "en",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+    const sourcesSimple = sourceIds.map((sid) => [sid]);
+
+    const formatConfigs: Record<string, { title: string; description: string; prompt: string }> = {
+      "Briefing Doc": {
+        title: "Briefing Doc",
+        description: "Key insights and important quotes",
+        prompt:
+          "Create a comprehensive briefing document that includes an " +
+          "Executive Summary, detailed analysis of key themes, important " +
+          "quotes with context, and actionable insights.",
+      },
+      "Study Guide": {
+        title: "Study Guide",
+        description: "Short-answer quiz, essay questions, glossary",
+        prompt:
+          "Create a comprehensive study guide that includes key concepts, " +
+          "short-answer practice questions, essay prompts for deeper " +
+          "exploration, and a glossary of important terms.",
+      },
+      "Blog Post": {
+        title: "Blog Post",
+        description: "Insightful takeaways in readable article format",
+        prompt:
+          "Write an engaging blog post that presents the key insights " +
+          "in an accessible, reader-friendly format. Include an attention-" +
+          "grabbing introduction, well-organized sections, and a compelling " +
+          "conclusion with takeaways.",
+      },
+      "Create Your Own": {
+        title: "Custom Report",
+        description: "Custom format",
+        prompt: customPrompt || "Create a report based on the provided sources.",
+      },
+    };
+
+    const config = formatConfigs[reportFormat];
+    if (!config) {
+      throw new Error(
+        `Invalid report format: ${reportFormat}. Valid: ${Object.keys(formatConfigs).join(", ")}`
+      );
+    }
+
+    const reportOptions = [
+      null,
+      [config.title, config.description, null, sourcesSimple, language, config.prompt, null, true],
+    ];
+
+    const content = [
+      null, null, STUDIO_TYPE.REPORT, sourcesNested,
+      null, null, null, reportOptions,
+    ];
+
+    const params = [[2], notebookId, content];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "report",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        format: reportFormat,
+        language,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Flashcards
+  // =========================================================================
+
+  async createFlashcards(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      difficulty?: number;
+      focusPrompt?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      difficulty = FLASHCARD_DIFFICULTY.MEDIUM,
+      focusPrompt = "",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+
+    const flashcardOptions = [
+      null,
+      [1, null, focusPrompt || null, null, null, null, [difficulty, FLASHCARD_COUNT_DEFAULT]],
+    ];
+
+    const content: unknown[] = [
+      null, null, STUDIO_TYPE.FLASHCARDS, sourcesNested,
+      null, null, null, null, null,
+      flashcardOptions,
+    ];
+
+    const params = [[2], notebookId, content];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "flashcards",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        difficulty: getFlashcardDifficultyName(difficulty),
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Quiz
+  // =========================================================================
+
+  async createQuiz(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      questionCount?: number;
+      difficulty?: number;
+      focusPrompt?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      questionCount = 2,
+      difficulty = FLASHCARD_DIFFICULTY.MEDIUM,
+      focusPrompt = "",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+
+    const quizOptions = [
+      null,
+      [2, null, focusPrompt || null, null, null, null, null, [questionCount, difficulty]],
+    ];
+
+    const content: unknown[] = [
+      null, null, STUDIO_TYPE.FLASHCARDS, sourcesNested,
+      null, null, null, null, null,
+      quizOptions,
+    ];
+
+    const params = [[2], notebookId, content];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "quiz",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        question_count: questionCount,
+        difficulty: getFlashcardDifficultyName(difficulty),
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Data Table
+  // =========================================================================
+
+  async createDataTable(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+      description?: string;
+      language?: string;
+    } = {}
+  ): Promise<StudioArtifact | null> {
+    const {
+      description = "",
+      language = "en",
+    } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+
+    const datatableOptions = [null, [description, language]];
+
+    const content: unknown[] = [
+      null, null, STUDIO_TYPE.DATA_TABLE, sourcesNested,
+      null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+      datatableOptions,
+    ];
+
+    const params = [[2], notebookId, content];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.CREATE_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const artifactData = result[0];
+      const artifactId =
+        Array.isArray(artifactData) && artifactData.length > 0 ? artifactData[0] : null;
+
+      return {
+        artifact_id: artifactId,
+        notebook_id: notebookId,
+        type: "data_table",
+        status: normalizeStudioStatus(artifactData as unknown[]),
+        description,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Mind Map
+  // =========================================================================
+
+  async generateMindMap(
+    notebookId: string,
+    options: {
+      sourceIds?: string[];
+    } = {}
+  ): Promise<{ mind_map_json: string | null; generation_id: string | null; source_ids: string[] } | null> {
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+    if (sourceIds.length === 0) {
+      throw new Error(`No sources found in notebook ${notebookId}. Add sources first.`);
+    }
+
+    const sourcesNested = sourceIds.map((sid) => [[sid]]);
+
+    const params = [
+      sourcesNested,
+      null, null, null, null,
+      ["interactive_mindmap", [["[CONTEXT]", ""]], ""],
+      null,
+      [2, null, [1]],
+    ];
+
+    const result = await this.rpcClient.callRpc(RPC_IDS.GENERATE_MIND_MAP, params);
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const inner = Array.isArray(result[0]) ? result[0] : result;
+      const mindMapJson = typeof inner[0] === "string" ? inner[0] : null;
+      let generationId: string | null = null;
+
+      if (inner.length > 2 && Array.isArray(inner[2]) && inner[2].length > 0) {
+        generationId = inner[2][0];
+      }
+
+      return {
+        mind_map_json: mindMapJson,
+        generation_id: generationId,
+        source_ids: sourceIds,
+      };
+    }
+
+    return null;
+  }
+
+  async saveMindMap(
+    notebookId: string,
+    mindMapJson: string,
+    options: {
+      sourceIds?: string[];
+      title?: string;
+    } = {}
+  ): Promise<{ mind_map_id: string | null; notebook_id: string; title: string } | null> {
+    const { title = "Mind Map" } = options;
+
+    let sourceIds = options.sourceIds;
+    if (!sourceIds || sourceIds.length === 0) {
+      sourceIds = await this.getSourceIds(notebookId);
+    }
+
+    const sourcesSimple = sourceIds.map((sid) => [sid]);
+    const metadata = [2, null, null, 5, sourcesSimple];
+    const params = [notebookId, mindMapJson, metadata, null, title];
+
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.SAVE_MIND_MAP,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    if (result && Array.isArray(result) && result.length > 0) {
+      const inner = Array.isArray(result[0]) ? result[0] : result;
+      const mindMapId = inner.length > 0 ? inner[0] : null;
+      const savedTitle = inner.length > 4 ? inner[4] : title;
+
+      return {
+        mind_map_id: mindMapId,
+        notebook_id: notebookId,
+        title: savedTitle ?? title,
+      };
+    }
+
+    return null;
+  }
+
+  // =========================================================================
+  // Status & Deletion
+  // =========================================================================
+
+  async pollStudioStatus(notebookId: string): Promise<StudioStatusArtifact[]> {
+    const params = [[2], notebookId, 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"'];
+    const result = await this.rpcClient.callRpc(
+      RPC_IDS.POLL_STUDIO,
+      params,
+      `/notebook/${notebookId}`
+    );
+
+    const artifacts: StudioStatusArtifact[] = [];
+
+    if (!result || !Array.isArray(result) || result.length === 0) return artifacts;
+
+    const artifactList = Array.isArray(result[0]) ? result[0] : result;
+
+    for (const artifactData of artifactList) {
+      if (!Array.isArray(artifactData) || artifactData.length < 5) continue;
+
+      const artifactId = artifactData[0];
+      const title = artifactData[1] ?? "";
+      const typeCode = artifactData[2];
+      const status = normalizeStudioStatus(artifactData);
+
+      let audioUrl: string | null = null;
+      let videoUrl: string | null = null;
+      let infographicUrl: string | null = null;
+      let slideDeckUrl: string | null = null;
+      let reportContent: string | null = null;
+      let flashcardCount: number | null = null;
+      let durationSeconds: number | null = null;
+
+      // Audio URLs
+      if (typeCode === STUDIO_TYPE.AUDIO && artifactData.length > 6) {
+        audioUrl = extractAudioMediaUrl(artifactData);
+        const audioOptions = artifactData[6];
+        if (Array.isArray(audioOptions) && audioOptions.length > 9 && Array.isArray(audioOptions[9])) {
+          durationSeconds = audioOptions[9][0] ?? null;
+        }
+      }
+
+      // Video URLs
+      if (typeCode === STUDIO_TYPE.VIDEO && artifactData.length > 8) {
+        const videoOptions = artifactData[8];
+        if (Array.isArray(videoOptions) && videoOptions.length > 3 && typeof videoOptions[3] === "string") {
+          videoUrl = videoOptions[3];
+        }
+      }
+
+      // Infographic URLs
+      if (typeCode === STUDIO_TYPE.INFOGRAPHIC && artifactData.length > 14) {
+        const infographicOptions = artifactData[14];
+        if (Array.isArray(infographicOptions) && infographicOptions.length > 2) {
+          const imageData = infographicOptions[2];
+          if (Array.isArray(imageData) && imageData.length > 0) {
+            const firstImage = imageData[0];
+            if (Array.isArray(firstImage) && firstImage.length > 1) {
+              const imageDetails = firstImage[1];
+              if (Array.isArray(imageDetails) && imageDetails.length > 0) {
+                const url = imageDetails[0];
+                if (typeof url === "string" && url.startsWith("http")) {
+                  infographicUrl = url;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Slide deck URLs
+      if (typeCode === STUDIO_TYPE.SLIDE_DECK && artifactData.length > 16) {
+        const sdOptions = artifactData[16];
+        if (Array.isArray(sdOptions) && sdOptions.length > 0) {
+          if (typeof sdOptions[0] === "string" && sdOptions[0].startsWith("http")) {
+            slideDeckUrl = sdOptions[0];
+          } else if (sdOptions.length > 3 && typeof sdOptions[3] === "string") {
+            slideDeckUrl = sdOptions[3];
+          }
+        }
+      }
+
+      // Report content
+      if (typeCode === STUDIO_TYPE.REPORT && artifactData.length > 7) {
+        const reportOptions = artifactData[7];
+        if (Array.isArray(reportOptions) && reportOptions.length > 1) {
+          const contentData = Array.isArray(reportOptions[1]) ? reportOptions[1] : null;
+          if (contentData && contentData.length > 0 && typeof contentData[0] === "string") {
+            reportContent = contentData[0];
+          }
+        }
+      }
+
+      // Flashcard/quiz count
+      if (typeCode === STUDIO_TYPE.FLASHCARDS && artifactData.length > 9) {
+        const fcOptions = artifactData[9];
+        if (Array.isArray(fcOptions) && fcOptions.length > 1) {
+          const cardsData = Array.isArray(fcOptions[1]) ? fcOptions[1] : null;
+          if (cardsData) {
+            flashcardCount = cardsData.length;
+          }
+        }
+      }
+
+      // Determine quiz vs flashcard
+      let artifactType = getStudioTypeName(typeCode);
+      if (typeCode === STUDIO_TYPE.FLASHCARDS && artifactData.length > 9) {
+        const fcOptions = artifactData[9];
+        if (Array.isArray(fcOptions) && fcOptions.length > 1) {
+          const inner = fcOptions[1];
+          if (Array.isArray(inner) && inner.length > 0 && inner[0] === 2) {
+            artifactType = "quiz";
+          }
+        }
+      }
+
+      artifacts.push({
+        artifact_id: artifactId,
+        title,
+        type: artifactType,
+        status,
+        audio_url: audioUrl,
+        video_url: videoUrl,
+        infographic_url: infographicUrl,
+        slide_deck_url: slideDeckUrl,
+        report_content: reportContent,
+        flashcard_count: flashcardCount,
+        duration_seconds: durationSeconds,
+      });
+    }
+
+    return artifacts;
+  }
+
+  async deleteStudioArtifact(artifactId: string): Promise<boolean> {
+    try {
+      const params = [[2], artifactId];
+      const result = await this.rpcClient.callRpc(RPC_IDS.DELETE_STUDIO, params);
+      return result !== null;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import {
 import { AuthManager } from "./auth/auth-manager.js";
 import { SessionManager } from "./session/session-manager.js";
 import { NotebookLibrary } from "./library/notebook-library.js";
-import { ToolHandlers, buildToolDefinitions } from "./tools/index.js";
+import { ToolHandlers, buildToolDefinitions, StudioHandlers } from "./tools/index.js";
 import { ResourceHandlers } from "./resources/resource-handlers.js";
 import { SettingsManager } from "./utils/settings-manager.js";
 import { CliHandler } from "./utils/cli-handler.js";
@@ -57,6 +57,7 @@ class NotebookLMMCPServer {
   private sessionManager: SessionManager;
   private library: NotebookLibrary;
   private toolHandlers: ToolHandlers;
+  private studioHandlers: StudioHandlers;
   private resourceHandlers: ResourceHandlers;
   private settingsManager: SettingsManager;
   private toolDefinitions: Tool[];
@@ -92,6 +93,7 @@ class NotebookLMMCPServer {
       this.authManager,
       this.library
     );
+    this.studioHandlers = new StudioHandlers(this.sessionManager);
     this.resourceHandlers = new ResourceHandlers(this.library);
 
     // Build and Filter tool definitions
@@ -266,6 +268,26 @@ class NotebookLMMCPServer {
           case "cleanup_data":
             result = await this.toolHandlers.handleCleanupData(
               args as { confirm: boolean }
+            );
+            break;
+
+          // Studio artifact tools
+          case "studio_create":
+            result = await this.studioHandlers.handleStudioCreate(
+              args as Record<string, unknown>,
+              sendProgress
+            );
+            break;
+
+          case "studio_status":
+            result = await this.studioHandlers.handleStudioStatus(
+              args as Record<string, unknown>
+            );
+            break;
+
+          case "studio_delete":
+            result = await this.studioHandlers.handleStudioDelete(
+              args as Record<string, unknown>
             );
             break;
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -13,6 +13,7 @@ import {
 import { notebookManagementTools } from "./definitions/notebook-management.js";
 import { sessionManagementTools } from "./definitions/session-management.js";
 import { systemTools } from "./definitions/system.js";
+import { studioTools } from "./definitions/studio.js";
 
 /**
  * Build Tool Definitions with NotebookLibrary context
@@ -29,5 +30,6 @@ export function buildToolDefinitions(library: NotebookLibrary): Tool[] {
     ...notebookManagementTools,
     ...sessionManagementTools,
     ...systemTools,
+    ...studioTools,
   ];
 }

--- a/src/tools/definitions/studio.ts
+++ b/src/tools/definitions/studio.ts
@@ -1,0 +1,185 @@
+/**
+ * Studio MCP Tool Definitions
+ *
+ * Defines all studio artifact generation tools for the MCP server.
+ */
+
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const studioCreateTool: Tool = {
+  name: "studio_create",
+  description:
+    "Create a studio artifact in a NotebookLM notebook. Supports: audio (podcast), video, infographic, slide_deck, report, quiz, flashcards, mind_map, data_table. " +
+    "Each type has specific options for format, style, difficulty, etc. The artifact is generated asynchronously - use studio_status to check progress.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      notebook_url: {
+        type: "string",
+        description: "NotebookLM notebook URL (e.g., https://notebooklm.google.com/notebook/<id>)",
+      },
+      artifact_type: {
+        type: "string",
+        enum: [
+          "audio",
+          "video",
+          "infographic",
+          "slide_deck",
+          "report",
+          "quiz",
+          "flashcards",
+          "mind_map",
+          "data_table",
+        ],
+        description: "Type of studio artifact to create",
+      },
+      focus_prompt: {
+        type: "string",
+        description:
+          "Optional focus prompt to guide artifact generation. Works for all types. " +
+          "E.g., 'Focus on the 9 Pillars of Wha-Dho' or 'Explain the business funnel'",
+      },
+      // Audio options
+      audio_format: {
+        type: "string",
+        enum: ["deep_dive", "brief", "critique", "debate"],
+        description: "Audio format (default: deep_dive). Only for audio type.",
+      },
+      audio_length: {
+        type: "string",
+        enum: ["short", "default", "long"],
+        description: "Audio length (default: default). Only for audio type.",
+      },
+      // Video options
+      video_format: {
+        type: "string",
+        enum: ["explainer", "brief", "cinematic"],
+        description: "Video format/depth (default: explainer). Only for video type.",
+      },
+      video_style: {
+        type: "string",
+        enum: [
+          "auto_select",
+          "classic",
+          "whiteboard",
+          "kawaii",
+          "anime",
+          "watercolor",
+          "retro_print",
+          "heritage",
+          "paper_craft",
+        ],
+        description: "Visual style (default: auto_select). Only for video type.",
+      },
+      video_style_prompt: {
+        type: "string",
+        description: "Custom visual style description. Only for video type with custom style.",
+      },
+      // Infographic options
+      infographic_orientation: {
+        type: "string",
+        enum: ["landscape", "portrait", "square"],
+        description: "Infographic orientation (default: landscape). Only for infographic type.",
+      },
+      infographic_detail: {
+        type: "string",
+        enum: ["concise", "standard", "detailed"],
+        description: "Detail level (default: standard). Only for infographic type.",
+      },
+      infographic_style: {
+        type: "string",
+        enum: [
+          "auto_select",
+          "sketch_note",
+          "professional",
+          "bento_grid",
+          "editorial",
+          "instructional",
+          "bricks",
+          "clay",
+          "anime",
+          "kawaii",
+          "scientific",
+        ],
+        description: "Visual style (default: auto_select). Only for infographic type.",
+      },
+      // Slide deck options
+      slide_format: {
+        type: "string",
+        enum: ["detailed_deck", "presenter_slides"],
+        description: "Slide format (default: detailed_deck). Only for slide_deck type.",
+      },
+      slide_length: {
+        type: "string",
+        enum: ["short", "default"],
+        description: "Slide deck length (default: default). Only for slide_deck type.",
+      },
+      // Report options
+      report_format: {
+        type: "string",
+        enum: ["Briefing Doc", "Study Guide", "Blog Post", "Create Your Own"],
+        description: "Report format (default: Briefing Doc). Only for report type.",
+      },
+      custom_prompt: {
+        type: "string",
+        description:
+          "Custom prompt for 'Create Your Own' report format. Also used as directive for tailored reports.",
+      },
+      // Quiz/Flashcard options
+      difficulty: {
+        type: "string",
+        enum: ["easy", "medium", "hard"],
+        description: "Difficulty level (default: medium). For quiz and flashcards types.",
+      },
+      question_count: {
+        type: "number",
+        description: "Number of questions (default: 2). Only for quiz type.",
+      },
+      // Data table options
+      table_description: {
+        type: "string",
+        description: "Description of the data table to create. Only for data_table type.",
+      },
+      // Language
+      language: {
+        type: "string",
+        description: "Language code (default: en)",
+      },
+    },
+    required: ["notebook_url", "artifact_type"],
+  },
+};
+
+export const studioStatusTool: Tool = {
+  name: "studio_status",
+  description:
+    "Check the status of all studio artifacts in a NotebookLM notebook. " +
+    "Returns artifact IDs, types, status (in_progress/completed/failed), and download URLs when available.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      notebook_url: {
+        type: "string",
+        description: "NotebookLM notebook URL",
+      },
+    },
+    required: ["notebook_url"],
+  },
+};
+
+export const studioDeleteTool: Tool = {
+  name: "studio_delete",
+  description: "Delete a studio artifact from a NotebookLM notebook. This action is IRREVERSIBLE.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      artifact_id: {
+        type: "string",
+        description: "The artifact UUID to delete",
+      },
+    },
+    required: ["artifact_id"],
+  },
+};
+
+export const studioTools: Tool[] = [studioCreateTool, studioStatusTool, studioDeleteTool];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,3 +6,4 @@
 
 export { buildToolDefinitions } from "./definitions.js";
 export { ToolHandlers } from "./handlers.js";
+export { StudioHandlers } from "./studio-handlers.js";

--- a/src/tools/studio-handlers.ts
+++ b/src/tools/studio-handlers.ts
@@ -1,0 +1,375 @@
+/**
+ * Studio Tool Handlers
+ *
+ * Implements MCP tool handlers for studio artifact generation.
+ * Extracts cookies from the Patchright browser session and uses
+ * the StudioClient for direct RPC calls to NotebookLM's API.
+ */
+
+// BrowserContext type not needed -- we access it via session manager internals
+import { StudioClient, extractNotebookId } from "../api/studio-client.js";
+import {
+  AUDIO_FORMAT,
+  AUDIO_LENGTH,
+  VIDEO_FORMAT,
+  VIDEO_STYLE,
+  INFOGRAPHIC_ORIENTATION,
+  INFOGRAPHIC_DETAIL,
+  INFOGRAPHIC_STYLE,
+  SLIDE_DECK_FORMAT,
+  SLIDE_DECK_LENGTH,
+  FLASHCARD_DIFFICULTY,
+} from "../api/constants.js";
+import type { ToolResult, ProgressCallback } from "../types.js";
+import { log } from "../utils/logger.js";
+import { SessionManager } from "../session/session-manager.js";
+
+// Name-to-code lookup maps
+const AUDIO_FORMAT_MAP: Record<string, number> = {
+  deep_dive: AUDIO_FORMAT.DEEP_DIVE,
+  brief: AUDIO_FORMAT.BRIEF,
+  critique: AUDIO_FORMAT.CRITIQUE,
+  debate: AUDIO_FORMAT.DEBATE,
+};
+
+const AUDIO_LENGTH_MAP: Record<string, number> = {
+  short: AUDIO_LENGTH.SHORT,
+  default: AUDIO_LENGTH.DEFAULT,
+  long: AUDIO_LENGTH.LONG,
+};
+
+const VIDEO_FORMAT_MAP: Record<string, number> = {
+  explainer: VIDEO_FORMAT.EXPLAINER,
+  brief: VIDEO_FORMAT.BRIEF,
+  cinematic: VIDEO_FORMAT.CINEMATIC,
+};
+
+const VIDEO_STYLE_MAP: Record<string, number> = {
+  auto_select: VIDEO_STYLE.AUTO_SELECT,
+  custom: VIDEO_STYLE.CUSTOM,
+  classic: VIDEO_STYLE.CLASSIC,
+  whiteboard: VIDEO_STYLE.WHITEBOARD,
+  kawaii: VIDEO_STYLE.KAWAII,
+  anime: VIDEO_STYLE.ANIME,
+  watercolor: VIDEO_STYLE.WATERCOLOR,
+  retro_print: VIDEO_STYLE.RETRO_PRINT,
+  heritage: VIDEO_STYLE.HERITAGE,
+  paper_craft: VIDEO_STYLE.PAPER_CRAFT,
+};
+
+const INFOGRAPHIC_ORIENTATION_MAP: Record<string, number> = {
+  landscape: INFOGRAPHIC_ORIENTATION.LANDSCAPE,
+  portrait: INFOGRAPHIC_ORIENTATION.PORTRAIT,
+  square: INFOGRAPHIC_ORIENTATION.SQUARE,
+};
+
+const INFOGRAPHIC_DETAIL_MAP: Record<string, number> = {
+  concise: INFOGRAPHIC_DETAIL.CONCISE,
+  standard: INFOGRAPHIC_DETAIL.STANDARD,
+  detailed: INFOGRAPHIC_DETAIL.DETAILED,
+};
+
+const INFOGRAPHIC_STYLE_MAP: Record<string, number> = {
+  auto_select: INFOGRAPHIC_STYLE.AUTO_SELECT,
+  sketch_note: INFOGRAPHIC_STYLE.SKETCH_NOTE,
+  professional: INFOGRAPHIC_STYLE.PROFESSIONAL,
+  bento_grid: INFOGRAPHIC_STYLE.BENTO_GRID,
+  editorial: INFOGRAPHIC_STYLE.EDITORIAL,
+  instructional: INFOGRAPHIC_STYLE.INSTRUCTIONAL,
+  bricks: INFOGRAPHIC_STYLE.BRICKS,
+  clay: INFOGRAPHIC_STYLE.CLAY,
+  anime: INFOGRAPHIC_STYLE.ANIME,
+  kawaii: INFOGRAPHIC_STYLE.KAWAII,
+  scientific: INFOGRAPHIC_STYLE.SCIENTIFIC,
+};
+
+const SLIDE_DECK_FORMAT_MAP: Record<string, number> = {
+  detailed_deck: SLIDE_DECK_FORMAT.DETAILED,
+  presenter_slides: SLIDE_DECK_FORMAT.PRESENTER,
+};
+
+const SLIDE_DECK_LENGTH_MAP: Record<string, number> = {
+  short: SLIDE_DECK_LENGTH.SHORT,
+  default: SLIDE_DECK_LENGTH.DEFAULT,
+};
+
+const DIFFICULTY_MAP: Record<string, number> = {
+  easy: FLASHCARD_DIFFICULTY.EASY,
+  medium: FLASHCARD_DIFFICULTY.MEDIUM,
+  hard: FLASHCARD_DIFFICULTY.HARD,
+};
+
+/**
+ * Studio tool handlers.
+ */
+export class StudioHandlers {
+  private sessionManager: SessionManager;
+  private studioClient: StudioClient | null = null;
+
+  constructor(sessionManager: SessionManager) {
+    this.sessionManager = sessionManager;
+  }
+
+  /**
+   * Get or create a StudioClient using the browser context for authenticated API calls.
+   */
+  private async getStudioClient(notebookUrl: string): Promise<StudioClient> {
+    // Get a session to get the browser context
+    const session = await this.sessionManager.getOrCreateSession(undefined, notebookUrl);
+
+    if (!this.studioClient) {
+      this.studioClient = new StudioClient();
+    }
+
+    // Try to get the page from the session
+    const page = (session as any).getPage?.();
+    if (page) {
+      this.studioClient.setPage(page);
+      return this.studioClient;
+    }
+
+    // Fall back to shared context manager
+    const sharedCtxMgr = (this.sessionManager as any).sharedContextManager;
+    if (sharedCtxMgr) {
+      const ctx = await sharedCtxMgr.getOrCreateContext();
+      this.studioClient.setContext(ctx);
+      return this.studioClient;
+    }
+
+    throw new Error("Could not access browser context for API calls");
+  }
+
+  /**
+   * Handle studio_create tool
+   */
+  async handleStudioCreate(
+    args: Record<string, unknown>,
+    sendProgress?: ProgressCallback
+  ): Promise<ToolResult> {
+    const notebookUrl = args.notebook_url as string;
+    const artifactType = args.artifact_type as string;
+    const focusPrompt = (args.focus_prompt as string) || "";
+    const language = (args.language as string) || "en";
+
+    log.info(`[STUDIO] Creating ${artifactType} artifact`);
+    log.info(`  Notebook: ${notebookUrl}`);
+
+    try {
+      const notebookId = extractNotebookId(notebookUrl);
+      await sendProgress?.("Initializing studio client...", 1, 4);
+
+      const client = await this.getStudioClient(notebookUrl);
+      await sendProgress?.(`Creating ${artifactType} artifact...`, 2, 4);
+
+      let result: unknown;
+
+      switch (artifactType) {
+        case "audio":
+          result = await client.createAudioOverview(notebookId, {
+            format: AUDIO_FORMAT_MAP[args.audio_format as string] ?? AUDIO_FORMAT.DEEP_DIVE,
+            length: AUDIO_LENGTH_MAP[args.audio_length as string] ?? AUDIO_LENGTH.DEFAULT,
+            language,
+            focusPrompt,
+          });
+          break;
+
+        case "video":
+          result = await client.createVideoOverview(notebookId, {
+            format: VIDEO_FORMAT_MAP[args.video_format as string] ?? VIDEO_FORMAT.EXPLAINER,
+            visualStyle: VIDEO_STYLE_MAP[args.video_style as string] ?? VIDEO_STYLE.AUTO_SELECT,
+            visualStylePrompt: (args.video_style_prompt as string) || "",
+            language,
+            focusPrompt,
+          });
+          break;
+
+        case "infographic":
+          result = await client.createInfographic(notebookId, {
+            orientation:
+              INFOGRAPHIC_ORIENTATION_MAP[args.infographic_orientation as string] ??
+              INFOGRAPHIC_ORIENTATION.LANDSCAPE,
+            detailLevel:
+              INFOGRAPHIC_DETAIL_MAP[args.infographic_detail as string] ??
+              INFOGRAPHIC_DETAIL.STANDARD,
+            visualStyle:
+              INFOGRAPHIC_STYLE_MAP[args.infographic_style as string] ??
+              INFOGRAPHIC_STYLE.AUTO_SELECT,
+            language,
+            focusPrompt,
+          });
+          break;
+
+        case "slide_deck":
+          result = await client.createSlideDeck(notebookId, {
+            format:
+              SLIDE_DECK_FORMAT_MAP[args.slide_format as string] ?? SLIDE_DECK_FORMAT.DETAILED,
+            length:
+              SLIDE_DECK_LENGTH_MAP[args.slide_length as string] ?? SLIDE_DECK_LENGTH.DEFAULT,
+            language,
+            focusPrompt,
+          });
+          break;
+
+        case "report":
+          result = await client.createReport(notebookId, {
+            reportFormat: (args.report_format as string) || "Briefing Doc",
+            customPrompt: (args.custom_prompt as string) || focusPrompt,
+            language,
+          });
+          break;
+
+        case "quiz":
+          result = await client.createQuiz(notebookId, {
+            questionCount: (args.question_count as number) || 2,
+            difficulty: DIFFICULTY_MAP[args.difficulty as string] ?? FLASHCARD_DIFFICULTY.MEDIUM,
+            focusPrompt,
+          });
+          break;
+
+        case "flashcards":
+          result = await client.createFlashcards(notebookId, {
+            difficulty: DIFFICULTY_MAP[args.difficulty as string] ?? FLASHCARD_DIFFICULTY.MEDIUM,
+            focusPrompt,
+          });
+          break;
+
+        case "mind_map": {
+          const mmResult = await client.generateMindMap(notebookId);
+          if (mmResult?.mind_map_json) {
+            const saved = await client.saveMindMap(notebookId, mmResult.mind_map_json, {
+              sourceIds: mmResult.source_ids,
+              title: focusPrompt || "Mind Map",
+            });
+            result = {
+              type: "mind_map",
+              status: "completed",
+              notebook_id: notebookId,
+              mind_map_id: saved?.mind_map_id,
+              title: saved?.title,
+              mind_map_json_preview: mmResult.mind_map_json.slice(0, 500) + "...",
+            };
+          } else {
+            result = null;
+          }
+          break;
+        }
+
+        case "data_table":
+          result = await client.createDataTable(notebookId, {
+            description: (args.table_description as string) || focusPrompt,
+            language,
+          });
+          break;
+
+        default:
+          return {
+            success: false,
+            error: `Unknown artifact type: ${artifactType}`,
+          };
+      }
+
+      if (!result) {
+        return {
+          success: false,
+          error: `Failed to create ${artifactType} artifact. The API returned no result.`,
+        };
+      }
+
+      await sendProgress?.(`${artifactType} artifact created successfully!`, 4, 4);
+      log.success(`[STUDIO] ${artifactType} artifact created`);
+
+      return {
+        success: true,
+        data: result,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      log.error(`[STUDIO] studio_create failed: ${errorMessage}`);
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Handle studio_status tool
+   */
+  async handleStudioStatus(args: Record<string, unknown>): Promise<ToolResult> {
+    const notebookUrl = args.notebook_url as string;
+
+    log.info(`[STUDIO] Checking studio status`);
+    log.info(`  Notebook: ${notebookUrl}`);
+
+    try {
+      const notebookId = extractNotebookId(notebookUrl);
+      const client = await this.getStudioClient(notebookUrl);
+      const artifacts = await client.pollStudioStatus(notebookId);
+
+      log.success(`[STUDIO] Found ${artifacts.length} artifacts`);
+
+      return {
+        success: true,
+        data: {
+          notebook_id: notebookId,
+          artifact_count: artifacts.length,
+          artifacts,
+        },
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      log.error(`[STUDIO] studio_status failed: ${errorMessage}`);
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Handle studio_delete tool
+   */
+  async handleStudioDelete(args: Record<string, unknown>): Promise<ToolResult> {
+    const artifactId = args.artifact_id as string;
+
+    log.info(`[STUDIO] Deleting artifact ${artifactId}`);
+
+    try {
+      if (!this.studioClient) {
+        // Try to initialize from an existing session
+        const sessions = this.sessionManager.getAllSessionsInfo();
+        if (sessions.length === 0) {
+          return {
+            success: false,
+            error: "No active sessions. Please use studio_status or studio_create first to establish a connection.",
+          };
+        }
+        await this.getStudioClient(sessions[0].notebook_url);
+      }
+
+      const client = this.studioClient!;
+
+      const deleted = await client.deleteStudioArtifact(artifactId);
+
+      if (deleted) {
+        log.success(`[STUDIO] Artifact ${artifactId} deleted`);
+        return {
+          success: true,
+          data: { deleted: true, artifact_id: artifactId },
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to delete artifact ${artifactId}`,
+        };
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      log.error(`[STUDIO] studio_delete failed: ${errorMessage}`);
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+}

--- a/test-studio.ts
+++ b/test-studio.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+/**
+ * Test script for studio artifact generation.
+ * Tests against Paul D'Souza's "Way of Harmony" notebook.
+ *
+ * Uses the persistent Chrome profile and executes API calls from within
+ * the browser context for proper cookie handling.
+ */
+
+import path from "path";
+import { chromium } from "patchright";
+import { StudioClient, extractNotebookId } from "./src/api/studio-client.js";
+
+const NOTEBOOK_URL = "https://notebooklm.google.com/notebook/51e20bb8-b012-45d8-9421-0fc6c6f338fa";
+const NOTEBOOK_ID = extractNotebookId(NOTEBOOK_URL);
+const CHROME_PROFILE = path.join(
+  process.env.HOME || "~",
+  "Library/Application Support/notebooklm-mcp/chrome_profile"
+);
+
+// Track results
+const results: Record<string, { success: boolean; error?: string; data?: any }> = {};
+
+async function testArtifact(name: string, fn: () => Promise<any>) {
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`Testing: ${name}`);
+  console.log("=".repeat(60));
+
+  try {
+    const result = await fn();
+    const preview = JSON.stringify(result, null, 2);
+    console.log(`SUCCESS: ${preview.length > 500 ? preview.slice(0, 500) + "..." : preview}`);
+    results[name] = { success: true, data: result };
+  } catch (error: any) {
+    console.log(`FAILED: ${error.message}`);
+    results[name] = { success: false, error: error.message };
+  }
+}
+
+async function main() {
+  console.log("Launching persistent Chrome context...");
+  const context = await chromium.launchPersistentContext(CHROME_PROFILE, {
+    headless: true,
+    channel: "chrome",
+    args: [
+      "--disable-blink-features=AutomationControlled",
+      "--disable-dev-shm-usage",
+      "--no-first-run",
+      "--no-default-browser-check",
+    ],
+  });
+
+  // Navigate to NotebookLM
+  const page = await context.newPage();
+  console.log("Navigating to NotebookLM...");
+  await page.goto("https://notebooklm.google.com/", {
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
+  });
+  await page.waitForTimeout(3000);
+
+  const finalUrl = page.url();
+  if (finalUrl.includes("accounts.google.com")) {
+    console.error("Auth expired. Run setup_auth to re-authenticate.");
+    await context.close();
+    process.exit(1);
+  }
+  console.log(`Authenticated! On: ${finalUrl}`);
+  console.log(`Notebook ID: ${NOTEBOOK_ID}`);
+
+  // Create StudioClient with the browser page
+  const client = new StudioClient();
+  client.setPage(page);
+
+  // Verify connectivity
+  console.log("\nVerifying API connectivity via studio status...");
+  try {
+    const status = await client.pollStudioStatus(NOTEBOOK_ID);
+    console.log(`Connected! Found ${status.length} existing artifacts.`);
+    for (const a of status) {
+      console.log(`  - ${a.type}: ${a.title} [${a.status}]`);
+    }
+  } catch (error: any) {
+    console.log(`Connectivity check failed: ${error.message}`);
+    console.log("Attempting to continue with tests anyway...");
+  }
+
+  // Test 1: Mind Map of the 9 Pillars of Wha-Dho
+  await testArtifact("Mind Map - 9 Pillars of Wha-Dho", () =>
+    client.generateMindMap(NOTEBOOK_ID).then(async (result) => {
+      if (result?.mind_map_json) {
+        const saved = await client.saveMindMap(NOTEBOOK_ID, result.mind_map_json, {
+          title: "9 Pillars of Wha-Dho",
+        });
+        return { generated: !!result.mind_map_json, saved };
+      }
+      return result;
+    })
+  );
+
+  // Test 2: Whiteboard-style video overview
+  await testArtifact("Video Overview - Whiteboard Style", () =>
+    client.createVideoOverview(NOTEBOOK_ID, {
+      format: 1, // explainer
+      visualStyle: 4, // whiteboard
+      focusPrompt: "Paul DeSouza's business philosophy and the Way of Harmony",
+    })
+  );
+
+  // Test 3: Slides for the 3-layer framework
+  await testArtifact("Slide Deck - 3-Layer Framework", () =>
+    client.createSlideDeck(NOTEBOOK_ID, {
+      focusPrompt: "The 3-layer framework: Wha-Dho, EUM, OpenExO",
+    })
+  );
+
+  // Test 4: Infographic of business funnel
+  await testArtifact("Infographic - Business Funnel", () =>
+    client.createInfographic(NOTEBOOK_ID, {
+      orientation: 2, // portrait
+      detailLevel: 3, // detailed
+      visualStyle: 3, // professional
+      focusPrompt: "Paul DeSouza's business funnel and coaching pipeline",
+    })
+  );
+
+  // Test 5: Audio deep dive on teaching metaphors
+  await testArtifact("Audio Overview - Deep Dive on Teaching Metaphors", () =>
+    client.createAudioOverview(NOTEBOOK_ID, {
+      format: 1, // deep_dive
+      length: 2, // default
+      focusPrompt: "Paul DeSouza's teaching metaphors and how they connect to his philosophy",
+    })
+  );
+
+  // Test 6: Quiz on the Wha-Dho philosophy
+  await testArtifact("Quiz - Wha-Dho Philosophy", () =>
+    client.createQuiz(NOTEBOOK_ID, {
+      difficulty: 2, // medium
+      questionCount: 5,
+      focusPrompt: "The Wha-Dho philosophy and its core principles",
+    })
+  );
+
+  // Test 7: Flashcards for key terminology
+  await testArtifact("Flashcards - Key Terminology", () =>
+    client.createFlashcards(NOTEBOOK_ID, {
+      difficulty: 2, // medium
+      focusPrompt: "Key terms and concepts from Paul DeSouza's teachings",
+    })
+  );
+
+  // Test 8: Tailored report for potential coaching clients
+  await testArtifact("Report - Coaching Client Overview", () =>
+    client.createReport(NOTEBOOK_ID, {
+      reportFormat: "Create Your Own",
+      customPrompt:
+        "Create a compelling overview of Paul DeSouza's coaching practice for potential clients. " +
+        "Include his philosophy, methodology (Wha-Dho), what clients can expect, and the transformation journey. " +
+        "Write in a warm, inviting tone that reflects Paul's conscious business approach.",
+    })
+  );
+
+  // Test 9: Data table
+  await testArtifact("Data Table - Key Concepts", () =>
+    client.createDataTable(NOTEBOOK_ID, {
+      description: "Key concepts, their definitions, and which pillar they belong to in the Wha-Dho framework",
+    })
+  );
+
+  // Wait a moment then check status
+  console.log("\nWaiting 10 seconds before checking final status...");
+  await new Promise((r) => setTimeout(r, 10000));
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("Final Studio Status Check");
+  console.log("=".repeat(60));
+
+  try {
+    const status = await client.pollStudioStatus(NOTEBOOK_ID);
+    console.log(`Found ${status.length} artifacts:`);
+    for (const a of status) {
+      console.log(`  - [${a.status.padEnd(12)}] ${a.type.padEnd(14)} ${a.title}`);
+      if (a.audio_url) console.log(`    Audio URL: ${a.audio_url.slice(0, 80)}...`);
+      if (a.video_url) console.log(`    Video URL: ${a.video_url.slice(0, 80)}...`);
+      if (a.infographic_url) console.log(`    Infographic URL: ${a.infographic_url.slice(0, 80)}...`);
+    }
+  } catch (error: any) {
+    console.log(`Status check failed: ${error.message}`);
+  }
+
+  // Summary
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("TEST SUMMARY");
+  console.log("=".repeat(60));
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const [name, result] of Object.entries(results)) {
+    const icon = result.success ? "PASS" : "FAIL";
+    console.log(`  [${icon}] ${name}${result.error ? ` -- ${result.error}` : ""}`);
+    if (result.success) passed++;
+    else failed++;
+  }
+
+  console.log(`\n  Total: ${passed + failed} | Passed: ${passed} | Failed: ${failed}`);
+
+  await context.close();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

Adds studio artifact generation to the MCP server via 3 new tools: `studio_create`, `studio_status`, and `studio_delete`. These tools create NotebookLM's rich media outputs programmatically -- something the upstream package currently lacks.

### Supported artifact types (9 total)

| Type | Options |
|------|---------|
| **Audio Overview** | Formats: deep_dive, brief, critique, debate. Lengths: short, default, long |
| **Video Overview** | Formats: explainer, brief, cinematic. Styles: classic, whiteboard, kawaii, anime, watercolor, retro_print, heritage, paper_craft |
| **Infographic** | Orientations: landscape, portrait, square. 11 visual styles |
| **Slide Deck** | Formats: detailed_deck, presenter_slides. Lengths: short, default |
| **Report** | Formats: Briefing Doc, Study Guide, Blog Post, Create Your Own |
| **Quiz** | Difficulty: easy/medium/hard. Configurable question count |
| **Flashcards** | Difficulty: easy/medium/hard |
| **Mind Map** | Two-step generate + save with title |
| **Data Table** | Structured data extraction with description |

All types support `focus_prompt` for guiding generation and `language` for localization.

### How it works

- **Direct RPC** to NotebookLM's internal `batchexecute` API (no browser automation for studio ops)
- **Cookie auth** via the existing Patchright browser session (calls `page.evaluate(fetch(...))` for proper domain matching)
- **CSRF auto-extraction** from the NotebookLM page, with retry on auth expiry
- Ported from [jacob-bd/notebooklm-mcp-cli](https://github.com/jacob-bd/notebooklm-mcp-cli) (Python, MIT license)

### New files

- `src/api/constants.ts` -- RPC IDs, studio type codes, enum mappings
- `src/api/rpc-client.ts` -- batchexecute HTTP client
- `src/api/studio-client.ts` -- Studio artifact CRUD methods
- `src/tools/definitions/studio.ts` -- MCP tool schemas
- `src/tools/studio-handlers.ts` -- Tool handler bridge
- `test-studio.ts` -- Integration test against live notebook

## Test results

Tested against a live NotebookLM notebook with 15+ sources

```
...

  Total: 9 | Passed: 9 | Failed: 0
```

All 9 artifact types create successfully and appear in studio status polling.

## Test plan

- [ ] Verify all 9 artifact types complete generation (not just start)
- [ ] Verify status polling returns download URLs for completed artifacts
- [ ] Test artifact deletion
- [ ] Test with different audio formats (brief, critique, debate)
- [ ] Test with different video styles (anime, watercolor, etc.)
- [ ] Test error handling when notebook has no sources
- [ ] Test auth recovery when session expires mid-operation
- [ ] Verify existing Q&A tools still work alongside studio tools
- [ ] Test with the profile-based tool filtering (settings-manager)