### PR TITLE
feat(config): expose ANSWER_TIMEOUT_MS for NotebookLM response wait

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export interface Config {
   // Browser Settings
   headless: boolean;
   browserTimeout: number;
+  answerTimeoutMs: number;
   viewport: { width: number; height: number };
 
   // Session Management
@@ -88,6 +89,7 @@ const DEFAULTS: Config = {
   // Browser Settings
   headless: true,
   browserTimeout: 30000,
+  answerTimeoutMs: 120000, // 2 minutes — wait for NotebookLM's streamed answer
   viewport: { width: 1024, height: 768 },
 
   // Session Management
@@ -171,6 +173,7 @@ function applyEnvOverrides(config: Config): Config {
     notebookUrl: process.env.NOTEBOOK_URL || config.notebookUrl,
     headless: parseBoolean(process.env.HEADLESS, config.headless),
     browserTimeout: parseInteger(process.env.BROWSER_TIMEOUT, config.browserTimeout),
+    answerTimeoutMs: parseInteger(process.env.ANSWER_TIMEOUT_MS, config.answerTimeoutMs),
     maxSessions: parseInteger(process.env.MAX_SESSIONS, config.maxSessions),
     sessionTimeout: parseInteger(process.env.SESSION_TIMEOUT, config.sessionTimeout),
     autoLoginEnabled: parseBoolean(process.env.AUTO_LOGIN_ENABLED, config.autoLoginEnabled),

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -409,7 +409,7 @@ export class BrowserSession {
       await sendProgress?.("Waiting for NotebookLM response (streaming detection active)...", 3, 5);
       const answer = await waitForLatestAnswer(page, {
         question,
-        timeoutMs: 120000, // 2 minutes
+        timeoutMs: CONFIG.answerTimeoutMs,
         pollIntervalMs: 1000,
         ignoreTexts: existingResponses,
         debug: false,


### PR DESCRIPTION
## Motivation

The wait timeout for NotebookLM's streamed answer in `BrowserSession.askQuestion` is currently hardcoded to 120000ms (2 min) at [`src/session/browser-session.ts:412`](https://github.com/PleasePrompto/notebooklm-mcp/blob/main/src/session/browser-session.ts#L412):

```ts
const answer = await waitForLatestAnswer(page, {
  question,
  timeoutMs: 120000, // 2 minutes
  ...
});
```

For long-form answers (e.g. review-paper extraction queries that produce 15+ findings), NotebookLM's streaming legitimately exceeds 2 min. When that happens the tool returns `"Timeout waiting for response from NotebookLM"`, the answer is stranded in the browser, and the session record retains no entry for the lost turn (`message_count` does not increment), so there is no way to recover the response.

Every other timeout in the codebase is env-tunable (`BROWSER_TIMEOUT`, `SESSION_TIMEOUT`, `AUTO_LOGIN_TIMEOUT_MS`), but this one is not. There is no tool parameter or env var that can extend the wait.

## Change

Add an `answerTimeoutMs` field to `Config`, defaulted to the existing 120000 (**no behavior change**), overridable via `ANSWER_TIMEOUT_MS`. Replace the hardcoded literal in `browser-session.ts` with `CONFIG.answerTimeoutMs`. Mirrors the existing pattern for the other three timeouts.

## Backward compatibility

Default is unchanged at 120000ms. Existing users who don't set `ANSWER_TIMEOUT_MS` see no change.

## Verification

- `npm install && npm run build` — passes (`tsc` clean).
- Diff is two files, four insertions, one deletion.

## Suggested follow-up (out of scope for this PR)

Add `ANSWER_TIMEOUT_MS` to `docs/configuration.md` alongside the other env vars. Happy to follow up with a docs-only PR if desired.