### PR TITLE
fix: support Japanese NotebookLM UI selectors

### DIFF
--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -46,6 +46,8 @@ export const Selectors = {
       'textarea[aria-label*="domanda" i]',
       'textarea[aria-label*="vraag" i]',
       'textarea[aria-label*="質問" i]',
+      'textarea[placeholder*="質問" i]',
+      'textarea[placeholder*="何かを作成" i]',
       'textarea[aria-label*="pergunta" i]',
     ],
     /**

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -137,14 +137,17 @@ export const Selectors = {
       'button[aria-label*="ソースを追加" i]',
     ],
     /**
-     * Real Material modal. `[role="dialog"]` is set by Angular synchronously
-     * the moment the modal mounts — race-free against the `.mdc-dialog--open`
-     * animation class and resistant to Material-UI version bumps. Avoid
-     * `.cdk-overlay-pane` (matches every dropdown / emoji picker / menu).
+     * Real Material modal. `[role="dialog"]` is the preferred anchor, but
+     * NotebookLM's current Material dialog can expose only container classes in
+     * some locales / overlay states. The `.cdk-overlay-pane` fallbacks are
+     * scoped to Add-source content so ordinary menus are not treated as dialogs.
      */
-    overlayPane: '[role="dialog"]',
-    overlayInput: '[role="dialog"] input[type="text"]:not([readonly])',
-    overlayTextarea: '[role="dialog"] textarea',
+    overlayPane:
+      '[role="dialog"], .mat-mdc-dialog-container, .mdc-dialog__container, .cdk-overlay-pane:has(button.drop-zone-icon-button), .cdk-overlay-pane:has(textarea)',
+    overlayInput:
+      ':is([role="dialog"], .mat-mdc-dialog-container, .mdc-dialog__container, .cdk-overlay-pane) input[type="text"]:not([readonly])',
+    overlayTextarea:
+      ':is([role="dialog"], .mat-mdc-dialog-container, .mdc-dialog__container, .cdk-overlay-pane) textarea',
     /**
      * Source-type buttons in the Add-source overlay. Google ships them
      * *without* aria-labels — the only stable, language-agnostic anchor is

--- a/src/notebooklm/sources.ts
+++ b/src/notebooklm/sources.ts
@@ -191,20 +191,30 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
     return;
   }
 
-  // Try the sidebar button first — fastest path on a populated notebook.
-  try {
-    await page
-      .locator(joinAlt(Selectors.sources.addButton))
-      .first()
-      .click({ timeout: 5_000 });
-    await page
-      .locator(Selectors.sources.overlayPane)
-      .first()
-      .waitFor({ state: "visible", timeout: 8_000 });
-    return;
-  } catch (err) {
-    log.warning(`  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`);
+  // Try the sidebar button first — fastest path on a populated notebook. Iterate
+  // visible candidates because NotebookLM can keep hidden duplicate buttons in
+  // the DOM during responsive/sidebar transitions.
+  for (const selector of Selectors.sources.addButton) {
+    const matches = page.locator(selector);
+    const count = await matches.count().catch(() => 0);
+
+    for (let i = 0; i < Math.min(count, 5); i++) {
+      const candidate = matches.nth(i);
+      if (!(await candidate.isVisible({ timeout: 500 }).catch(() => false))) {
+        continue;
+      }
+
+      try {
+        await candidate.click({ timeout: 5_000 });
+        await waitForAddSourceOverlay(page, 8_000);
+        return;
+      } catch (err) {
+        log.warning(`  ⚠️  Add-source button candidate failed (${selector} #${i}: ${err})`);
+      }
+    }
   }
+
+  log.warning("  ⚠️  Add-source button click failed, trying ?addSource=true URL fallback");
 
   // URL fallback — useful when the sidebar button is hidden or covered.
   const url = page.url();
@@ -212,10 +222,7 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
     const u = new URL(url);
     u.searchParams.set("addSource", "true");
     await page.goto(u.toString(), { waitUntil: "domcontentloaded", timeout: 15_000 });
-    await page
-      .locator(Selectors.sources.overlayPane)
-      .first()
-      .waitFor({ state: "visible", timeout: 10_000 });
+    await waitForAddSourceOverlay(page, 10_000);
     return;
   }
 
@@ -223,19 +230,30 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
 }
 
 async function isOverlayVisible(page: Page): Promise<boolean> {
-  return page
-    .locator(Selectors.sources.overlayPane)
-    .first()
-    .isVisible({ timeout: 500 })
+  return waitForAddSourceOverlay(page, 500)
+    .then(() => true)
     .catch(() => false);
+}
+
+async function waitForAddSourceOverlay(page: Page, timeoutMs: number): Promise<void> {
+  const readySelectors = [
+    ...Selectors.sources.sourceTypeUrl,
+    ...Selectors.sources.sourceTypeText,
+    Selectors.sources.overlayInput,
+    Selectors.sources.overlayTextarea,
+  ];
+
+  await page
+    .locator(joinAlt(readySelectors))
+    .first()
+    .waitFor({ state: "visible", timeout: timeoutMs });
 }
 
 async function pickSourceType(page: Page, type: SourceType): Promise<void> {
   const candidates =
     type === "url" ? Selectors.sources.sourceTypeUrl : Selectors.sources.sourceTypeText;
-  const overlay = page.locator(Selectors.sources.overlayPane).first();
   for (const sel of candidates) {
-    const target = overlay.locator(sel).first();
+    const target = page.locator(sel).first();
     if (await target.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await target.click();
       // Sub-dialog needs a moment to hydrate before we type.

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -183,14 +183,30 @@ export class BrowserSession {
       });
       log.success("  ✅ Chat input ready!");
     } catch {
-      // FALLBACK: Python alternative selector
+      // FALLBACK: locale-specific selectors observed in current NotebookLM.
       try {
-        log.info("  ⏳ Trying fallback selector (aria-label)...");
-        await this.page.waitForSelector('textarea[aria-label="Feld für Anfragen"]', {
-          timeout: 5000, // Python uses 5s for fallback
-          state: "visible",
-        });
-        log.success("  ✅ Chat input ready (fallback)!");
+        log.info("  ⏳ Trying fallback selectors (aria-label / placeholder)...");
+        const fallbackSelectors = [
+          'textarea[aria-label="Feld für Anfragen"]',
+          'textarea[aria-label*="質問" i]',
+          'textarea[placeholder*="質問" i]',
+          'textarea[placeholder*="何かを作成" i]',
+        ];
+
+        for (const selector of fallbackSelectors) {
+          try {
+            await this.page.waitForSelector(selector, {
+              timeout: 5000, // Python uses 5s for fallback
+              state: "visible",
+            });
+            log.success(`  ✅ Chat input ready (fallback: ${selector})!`);
+            return;
+          } catch {
+            continue;
+          }
+        }
+
+        throw new Error("No fallback selector matched the NotebookLM chat input.");
       } catch (error) {
         log.error(`  ❌ NotebookLM interface not ready: ${error}`);
         throw new Error(
@@ -565,6 +581,9 @@ export class BrowserSession {
       'textarea[aria-label*="requete" i]',
       'textarea[aria-label*="consulta" i]',
       'textarea[aria-label*="domanda" i]',
+      'textarea[aria-label*="質問" i]',
+      'textarea[placeholder*="質問" i]',
+      'textarea[placeholder*="何かを作成" i]',
     ];
 
     const tryFind = async (): Promise<string | null> => {


### PR DESCRIPTION
## Summary
- add Japanese chat textarea placeholder selectors for current NotebookLM JA UI
- make Add source dialog detection more tolerant of current Material dialog/container markup
- click the first visible Add source button candidate instead of relying on the first selector match
- include Japanese placeholder fallbacks in the central selector registry

## Context
In the current Japanese NotebookLM UI, the chat textarea can be visible with placeholder text like `質問をするか、何かを作成してみましょう` while the existing wait path only checks `textarea.query-box-input` and the German aria-label fallback. This can make `ask_question` fail with `Could not find NotebookLM chat input` even though the chat box is present.

The Add source flow also changed enough that a visible dialog may be represented through Material dialog/container classes and content controls rather than the narrow `[role="dialog"]` path in all states. This can make `add_source` fail with `Could not open the "Add source" dialog`.

## Verification
- `npm ci` completed and built successfully; npm reported existing engine warnings under Node v23.11.0 and existing audit findings.
- `npm run lint && npm run build` passed. Lint reports one existing warning in `src/transport/http.ts` unrelated to this change.
- `git diff --check` passed.

## Local reproduction note
The chat selector fix was verified locally against a Japanese NotebookLM notebook where the chat input placeholder was `質問をするか、何かを作成してみましょう`. The Add source dialog selectors were checked against the current Japanese UI, where the visible dialog exposes Material dialog/container classes, source type buttons, and pasted-text textareas.
