### PR TITLE
fix: handle repeated NotebookLM answers

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "tsx watch src/index.ts",
     "prepare": "npm run build",
     "test": "tsx src/index.ts",
+    "test:unit": "tsx --test test/*.test.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write src",

--- a/src/notebooklm/chat.ts
+++ b/src/notebooklm/chat.ts
@@ -200,21 +200,49 @@ export interface AskOptions {
   pollIntervalMs?: number;
   /** Texts known *before* the question was submitted. Used to skip prior answers. */
   ignoreTexts?: string[];
+  /** Number of visible answer elements before the question was submitted. */
+  priorAnswerCount?: number;
   /** How many consecutive identical polls count as "answer settled". Default 3. */
   stablePolls?: number;
 }
 
+export interface PriorAnswerSnapshot {
+  /** Number of visible answer elements before the question was submitted. */
+  count: number;
+  /** Sanitized answer texts known before the question was submitted. */
+  texts: string[];
+}
+
+interface LatestAnswer {
+  text: string;
+  isNewAnswerElement: boolean;
+}
+
 /**
  * Snapshot every visible assistant answer text *before* a new question is
- * submitted. Pass the result into `waitForStableAnswer({ ignoreTexts })` so
- * the new turn isn't confused with prior turns in the same session.
+ * submitted. Kept for callers that only need prior text filtering; new callers
+ * should prefer `snapshotPriorAnswerState` so repeated answer text is safe.
  */
 export async function snapshotPriorAnswers(page: Page): Promise<string[]> {
-  return page
-    .locator(Selectors.chat.answerText)
-    .allInnerTexts()
-    .then((texts) => texts.map((t) => t.trim()).filter(Boolean))
-    .catch(() => []);
+  return snapshotPriorAnswerState(page).then((snapshot) => snapshot.texts);
+}
+
+/**
+ * Snapshot visible assistant answers and their DOM count before submitting.
+ * Text alone is not a safe identity because two legitimate turns may produce
+ * the same answer; the count lets the wait logic distinguish old and new turns.
+ */
+export async function snapshotPriorAnswerState(page: Page): Promise<PriorAnswerSnapshot> {
+  try {
+    const answers = page.locator(Selectors.chat.answerText);
+    const rawTexts = await answers.allInnerTexts();
+    return {
+      count: await answers.count(),
+      texts: rawTexts.map((text) => sanitizeAnswer(text)).filter(Boolean),
+    };
+  } catch {
+    return { count: 0, texts: [] };
+  }
 }
 
 /**
@@ -233,6 +261,7 @@ export async function waitForStableAnswer(
     timeoutMs = 600_000,
     pollIntervalMs = 750,
     ignoreTexts = [],
+    priorAnswerCount = ignoreTexts.length,
     stablePolls = 3,
   } = options;
 
@@ -256,17 +285,18 @@ export async function waitForStableAnswer(
       throw new Error("Browser page unresponsive: health check timed out");
     }
 
-    let candidate: string | null = null;
+    let latest: LatestAnswer | null = null;
     try {
-      candidate = await readLatestAnswer(page);
+      latest = await readLatestAnswer(page, priorAnswerCount);
     } catch (err) {
       if (isRecoverable(err)) throw err;
       // Non-fatal extraction blip — try again next tick.
     }
 
+    const candidate = latest?.text ?? null;
     if (candidate) {
       const isEcho = candidate.toLowerCase() === echoLower;
-      const isPrior = ignoreSet.has(candidate);
+      const isPrior = !latest?.isNewAnswerElement && ignoreSet.has(candidate);
 
       if (!isEcho && !isPrior) {
         // Loading placeholders ("Parsing the data…", "Thinking…", …) are
@@ -307,14 +337,16 @@ export async function waitForStableAnswer(
  * Read the latest answer container's text and strip UI-control leakage.
  * Uses `:last-child` so we always target the most recent turn.
  */
-async function readLatestAnswer(page: Page): Promise<string | null> {
+async function readLatestAnswer(page: Page, priorAnswerCount = 0): Promise<LatestAnswer | null> {
   try {
-    const raw = await page
-      .locator(Selectors.chat.latestAnswerText)
-      .last()
-      .innerText({ timeout: 2_000 });
+    const answers = page.locator(Selectors.chat.answerText);
+    const count = await answers.count();
+    const isNewAnswerElement = count > priorAnswerCount;
+    const raw = isNewAnswerElement
+      ? await answers.nth(count - 1).innerText({ timeout: 2_000 })
+      : await page.locator(Selectors.chat.latestAnswerText).last().innerText({ timeout: 2_000 });
     const cleaned = sanitizeAnswer(raw);
-    return cleaned.length > 0 ? cleaned : null;
+    return cleaned.length > 0 ? { text: cleaned, isNewAnswerElement } : null;
   } catch {
     return null;
   }

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -18,7 +18,7 @@ import type { SharedContextManager } from "./shared-context-manager.js";
 import type { AuthManager } from "../auth/auth-manager.js";
 import { humanType, randomDelay } from "../utils/stealth-utils.js";
 import { snapshotAllResponses } from "../utils/page-utils.js";
-import { waitForStableAnswer, snapshotPriorAnswers } from "../notebooklm/chat.js";
+import { waitForStableAnswer, snapshotPriorAnswerState } from "../notebooklm/chat.js";
 import {
   extractCitations as extractCitationsFromPage,
   type SourceFormat,
@@ -385,11 +385,14 @@ export class BrowserSession {
       // (issue #43). Falls back to the legacy snapshot only if the v2 helper
       // produced nothing, so we don't regress when the new selectors miss.
       log.info(`  📸 Snapshotting existing responses...`);
-      let existingResponses = await snapshotPriorAnswers(page);
-      if (existingResponses.length === 0) {
-        existingResponses = await snapshotAllResponses(page);
+      let existingResponseSnapshot = await snapshotPriorAnswerState(page);
+      if (existingResponseSnapshot.texts.length === 0) {
+        existingResponseSnapshot = {
+          count: existingResponseSnapshot.count,
+          texts: await snapshotAllResponses(page),
+        };
       }
-      log.success(`  ✅ Captured ${existingResponses.length} existing responses`);
+      log.success(`  ✅ Captured ${existingResponseSnapshot.texts.length} existing responses`);
 
       // Find the chat input
       const inputSelector = await this.findChatInput();
@@ -427,7 +430,8 @@ export class BrowserSession {
         question,
         timeoutMs: CONFIG.answerTimeoutMs,
         pollIntervalMs: 750,
-        ignoreTexts: existingResponses,
+        ignoreTexts: existingResponseSnapshot.texts,
+        priorAnswerCount: existingResponseSnapshot.count,
       });
 
       if (!answer) {

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Page } from "patchright";
+import { waitForStableAnswer } from "../src/notebooklm/chat.js";
+import { Selectors } from "../src/notebooklm/selectors.js";
+
+function createMockPage(answers: string[]): Page {
+  return {
+    isClosed: () => false,
+    evaluate: async () => true,
+    waitForTimeout: async () => undefined,
+    locator: (selector: string) => {
+      if (selector === Selectors.chat.answerText) {
+        return {
+          count: async () => answers.length,
+          allInnerTexts: async () => answers,
+          nth: (index: number) => ({
+            innerText: async () => answers[index] ?? "",
+          }),
+        };
+      }
+
+      if (selector === Selectors.chat.latestAnswerText) {
+        return {
+          last: () => ({
+            innerText: async () => answers[answers.length - 1] ?? "",
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected selector: ${selector}`);
+    },
+  } as unknown as Page;
+}
+
+test("returns a repeated answer when it appears in a new answer element", async () => {
+  const answer = await waitForStableAnswer(createMockPage(["pineapple", "pineapple"]), {
+    ignoreTexts: ["pineapple"],
+    priorAnswerCount: 1,
+    pollIntervalMs: 1,
+    timeoutMs: 50,
+    stablePolls: 1,
+  });
+
+  assert.equal(answer, "pineapple");
+});
+
+test("continues to ignore prior text when no new answer element exists", async () => {
+  const answer = await waitForStableAnswer(createMockPage(["pineapple"]), {
+    ignoreTexts: ["pineapple"],
+    priorAnswerCount: 1,
+    pollIntervalMs: 1,
+    timeoutMs: 10,
+    stablePolls: 1,
+  });
+
+  assert.equal(answer, null);
+});


### PR DESCRIPTION
This pull request improves the reliability of detecting new assistant answers by tracking both visible answer texts and their DOM count. This makes it possible to distinguish repeated answers in new answer elements from prior responses with the same text.
## Enhancements to answer detection logic
- Added a new `PriorAnswerSnapshot` interface and `snapshotPriorAnswerState` function in `src/notebooklm/chat.ts` to track both the count and texts of visible answer elements.
- Updated `waitForStableAnswer` to use the prior answer count when determining whether the latest visible answer is from a new turn.
- Updated `src/session/browser-session.ts` to use `snapshotPriorAnswerState` and pass both prior texts and prior count to `waitForStableAnswer`.
## Testing improvements
- Added `test/chat.test.ts` to verify that repeated answers in new elements are accepted.
- Added coverage to ensure prior texts are still ignored when no new answer element exists.
- Added a `test:unit` script to `package.json` for running unit tests.