### PR TITLE
fix(add_source): resolve dialog selector mis-match + sticky URL dead-state

### DIFF
--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -135,14 +135,32 @@ export const Selectors = {
       'button[aria-label*="ソースを追加" i]',
     ],
     /**
-     * Real Material modal. `[role="dialog"]` is set by Angular synchronously
-     * the moment the modal mounts — race-free against the `.mdc-dialog--open`
-     * animation class and resistant to Material-UI version bumps. Avoid
-     * `.cdk-overlay-pane` (matches every dropdown / emoji picker / menu).
+     * Real Material modal. `[role="dialog"]` alone is too narrow and too
+     * broad at the same time:
+     *  • Too narrow — NotebookLM 2026 sometimes renders the modal as
+     *    `mat-dialog-container` or a `[aria-modal="true"]` element with no
+     *    explicit role.
+     *  • Too broad — the page always carries a hidden Emoji-palette dialog
+     *    (`[role="dialog" aria-label="Emoji characters palette"]`); a bare
+     *    selector matches it first, and `.first().waitFor({state:visible})`
+     *    then blocks forever waiting on a hidden element. Locally observed
+     *    with `24 × locator resolved to hidden <div role="dialog"
+     *    aria-label="Emoji characters palette">` before a 10 s timeout.
+     * Fix: union of three modal-flavored anchors, scoped to :visible and
+     * excluding the Emoji palette by aria-label. Resistant to Material-UI
+     * version bumps without re-introducing the dropdown/menu false
+     * positives that `.cdk-overlay-pane` would cause. See issue #46.
      */
-    overlayPane: '[role="dialog"]',
-    overlayInput: '[role="dialog"] input[type="text"]:not([readonly])',
-    overlayTextarea: '[role="dialog"] textarea',
+    overlayPane:
+      '[role="dialog"]:not([aria-label*="Emoji" i]):visible, mat-dialog-container:visible, [aria-modal="true"]:visible',
+    overlayInput:
+      '[role="dialog"]:not([aria-label*="Emoji" i]):visible input[type="text"]:not([readonly]), ' +
+      'mat-dialog-container:visible input[type="text"]:not([readonly]), ' +
+      '[aria-modal="true"]:visible input[type="text"]:not([readonly])',
+    overlayTextarea:
+      '[role="dialog"]:not([aria-label*="Emoji" i]):visible textarea, ' +
+      "mat-dialog-container:visible textarea, " +
+      '[aria-modal="true"]:visible textarea',
     /**
      * Source-type buttons in the Add-source overlay. Google ships them
      * *without* aria-labels — the only stable, language-agnostic anchor is
@@ -313,7 +331,7 @@ export const Selectors = {
      * contains the Download item.
      */
     audioMoreMenuButton: [
-      "artifact-library-item button:has(mat-icon:text-is(\"more_vert\"))",
+      'artifact-library-item button:has(mat-icon:text-is("more_vert"))',
       'artifact-library-item button[aria-label*="mehr" i]',
       'artifact-library-item button[aria-label*="more" i]',
       'artifact-library-item button[aria-label*="plus" i]',

--- a/src/notebooklm/sources.ts
+++ b/src/notebooklm/sources.ts
@@ -86,9 +86,7 @@ export async function addSource(page: Page, input: AddSourceInput): Promise<AddS
       const currentUrl = page.url();
       const currentUuid = currentUrl.match(/notebook\/([a-f0-9-]+)/)?.[1];
       if (currentUuid && currentUuid !== expectedUuid) {
-        log.error(
-          `  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`
-        );
+        log.error(`  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`);
         return {
           success: false,
           type: input.type,
@@ -193,24 +191,37 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
 
   // Try the sidebar button first — fastest path on a populated notebook.
   try {
-    await page
-      .locator(joinAlt(Selectors.sources.addButton))
-      .first()
-      .click({ timeout: 5_000 });
+    await page.locator(joinAlt(Selectors.sources.addButton)).first().click({ timeout: 5_000 });
     await page
       .locator(Selectors.sources.overlayPane)
       .first()
       .waitFor({ state: "visible", timeout: 8_000 });
     return;
   } catch (err) {
-    log.warning(`  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`);
+    log.warning(
+      `  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`
+    );
   }
 
   // URL fallback — useful when the sidebar button is hidden or covered.
+  //
+  // PATCH 2026-05: drop the `!url.includes("addSource=true")` short-circuit.
+  // Once a previous attempt navigates to `?addSource=true` and the modal
+  // never opens (e.g. selector miss), the URL stays sticky on every
+  // subsequent BrowserSession reuse. The next add_source call then fails
+  // the if-check and falls straight through to the `throw` below — a
+  // permanent dead state cleared only by killing the session.
+  // Fix: strip any existing `addSource`/`_t` params first, then re-add
+  // `addSource=true` plus a `_t` cache-buster so the navigation is
+  // guaranteed to be a fresh hit even when the URL was already sticky.
+  // See issue #46 ("post-bootstrap add_source silent-drop").
   const url = page.url();
-  if (url && /\/notebook\//.test(url) && !url.includes("addSource=true")) {
+  if (url && /\/notebook\//.test(url)) {
     const u = new URL(url);
+    u.searchParams.delete("addSource");
+    u.searchParams.delete("_t");
     u.searchParams.set("addSource", "true");
+    u.searchParams.set("_t", String(Date.now()));
     await page.goto(u.toString(), { waitUntil: "domcontentloaded", timeout: 15_000 });
     await page
       .locator(Selectors.sources.overlayPane)


### PR DESCRIPTION
## Summary

Two bugs in `addSource` cause **every** call to fail with
`Could not open the "Add source" dialog` after the first attempt
mis-opens the modal — matching the *post-bootstrap add_source silent-drop*
failure mode reported in #46.

Both fixes are in `src/notebooklm/` and tested live against
notebooklm.google.com (EN locale, 2026-05) with a real Google AI Pro
account. After the patch I can repeatedly add URL and text sources to
the same notebook within a single MCP session, without restart.

## Bugs

### 1. Sticky URL dead-state — `sources.ts`

```ts
// before
if (url && /\/notebook\//.test(url) && !url.includes("addSource=true")) {
```

The `!url.includes("addSource=true")` guard was there to avoid
re-navigating when we believed we were already on the add-source URL.
But if a previous attempt navigated to `?addSource=true` and the
overlay never appeared (selector miss — see bug 2), the URL stays
sticky on the BrowserSession's reused page. Every subsequent call
then fails the if-check and falls straight through to
`throw new Error('Could not open the "Add source" dialog')`.

**Fix**: drop the short-circuit; explicitly strip any stale
`addSource`/`_t` params and re-set them with a fresh `_t = Date.now()`
cache-buster so the navigation is guaranteed to be a real hit.

### 2. Emoji-palette false positive — `selectors.ts`

```ts
// before
overlayPane: '[role="dialog"]',
```

The page carries a hidden Emoji-palette dialog
(`[role="dialog" aria-label="Emoji characters palette"]`).
`.locator(overlayPane).first()` matches that hidden element first;
`waitFor({state:"visible"})` then blocks waiting for it to become
visible (it never does), and Playwright eventually surfaces:

```
locator.waitFor: Timeout 10000ms exceeded.
  - waiting for locator('[role="dialog"]').first() to be visible
    24 × locator resolved to hidden <div role="dialog"
    aria-label="Emoji characters palette" ...>
```

**Fix**: scope `overlayPane` to `:visible` and exclude the Emoji
palette by aria-label. Union with `mat-dialog-container` and
`[aria-modal="true"]` as defence against UI variants that drop the
explicit `role` attribute. `.cdk-overlay-pane` is still avoided to
keep dropdowns / menus out of scope, per the original comment intent.
`overlayInput` and `overlayTextarea` get the same scoping treatment
since they target descendants of overlayPane.

## Test plan

- [x] `npm run lint` — no new warnings
- [x] `npm run build` — clean
- [x] Live: PleasePrompto v2.0.0 unmodified → repro: `add_source` succeeds
      once, subsequent calls fail with `Could not open the "Add source"
      dialog`. Patched: 30+ consecutive `add_source` calls succeed in a
      single MCP session (used to ingest 31 PDD chapters as URL sources
      + one text canary).

## Notes

- Prettier auto-reformatted two adjacent unrelated lines (the
  `audioMoreMenuButton` quote escape and one wrapped `log.error`).
  Kept those since they match the project's own prettier config.
- `[role="dialog"]:visible` and `:not([aria-label*="Emoji" i])`
  are Playwright pseudo-selectors, evaluated client-side — no
  performance cost vs the bare selector.

Refs #46