### PR TITLE
chore: ignore local worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ venv/
 .playwright-mcp/
 tmp/
 studio-*.png
+.worktrees/


### PR DESCRIPTION
## Summary
- ignore the local `.worktrees/` directory in `.gitignore`
- prevent machine-specific worktree metadata from being committed

## Why
This repository may be used with git worktrees locally, and that directory should remain untracked.