### PR TITLE
Fix add_source on current Add sources picker

### DIFF
--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -124,7 +124,11 @@ export const Selectors = {
     addButton: [
       "button.add-source-button",
       'button[aria-label="Add source"]',
+      'button[aria-label="Add sources"]',
       'button[aria-label*="add source" i]',
+      'button[aria-label*="add sources" i]',
+      'button:has-text("Add source")',
+      'button:has-text("Add sources")',
       'button[aria-label*="quelle hinzu" i]',
       'button[aria-label*="ajouter une source" i]',
       'button[aria-label*="añadir fuente" i]',
@@ -143,6 +147,17 @@ export const Selectors = {
     overlayPane: '[role="dialog"]',
     overlayInput: '[role="dialog"] input[type="text"]:not([readonly])',
     overlayTextarea: '[role="dialog"] textarea',
+    /**
+     * Current NotebookLM builds can expose the Add sources picker as a source
+     * menu before, or instead of, a strict dialog role. Treat these controls as
+     * a ready add-source UI so source ingestion does not fail before typing.
+     */
+    sourcePickerReady: [
+      'button.drop-zone-icon-button:has(mat-icon:text-is("upload"))',
+      'button.drop-zone-icon-button:has-text("Upload files")',
+      'button.drop-zone-icon-button:has-text("Upload sources")',
+      'input[type="file"]',
+    ],
     /**
      * Source-type buttons in the Add-source overlay. Google ships them
      * *without* aria-labels — the only stable, language-agnostic anchor is
@@ -313,7 +328,7 @@ export const Selectors = {
      * contains the Download item.
      */
     audioMoreMenuButton: [
-      "artifact-library-item button:has(mat-icon:text-is(\"more_vert\"))",
+      'artifact-library-item button:has(mat-icon:text-is("more_vert"))',
       'artifact-library-item button[aria-label*="mehr" i]',
       'artifact-library-item button[aria-label*="more" i]',
       'artifact-library-item button[aria-label*="plus" i]',

--- a/src/notebooklm/sources.ts
+++ b/src/notebooklm/sources.ts
@@ -27,7 +27,7 @@
  *      after the dialog closes (up to 90 s — URL crawls are slow).
  */
 
-import type { Page } from "patchright";
+import type { Locator, Page } from "patchright";
 import { Selectors, joinAlt } from "./selectors.js";
 import { safeSleep, isRecoverable } from "../browser/watchdog.js";
 import { log } from "../utils/logger.js";
@@ -86,9 +86,7 @@ export async function addSource(page: Page, input: AddSourceInput): Promise<AddS
       const currentUrl = page.url();
       const currentUuid = currentUrl.match(/notebook\/([a-f0-9-]+)/)?.[1];
       if (currentUuid && currentUuid !== expectedUuid) {
-        log.error(
-          `  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`
-        );
+        log.error(`  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`);
         return {
           success: false,
           type: input.type,
@@ -182,28 +180,28 @@ export async function countSources(page: Page): Promise<number> {
 /**
  * Open the Add-source modal. Order of attempts:
  *   1. Dialog already open → use it (auto-modal on fresh notebooks).
- *   2. Click the sidebar "Add source" button.
- *   3. Last resort: navigate to `?addSource=true`, which auto-opens.
+ *   2. Open the Sources panel if the current layout exposes one.
+ *   3. Click the sidebar "Add source" / "Add sources" button.
+ *   4. Last resort: navigate to `?addSource=true`, which auto-opens.
  */
 async function openAddSourceOverlay(page: Page): Promise<void> {
-  if (await isOverlayVisible(page)) {
-    log.info("  ✅ Add-source dialog already open, reusing");
+  if (await isAddSourceUiVisible(page)) {
+    log.info("  ✅ Add-source UI already open, reusing");
     return;
   }
 
+  await ensureSourcesPanel(page);
+  if (await isAddSourceUiVisible(page)) return;
+
   // Try the sidebar button first — fastest path on a populated notebook.
   try {
-    await page
-      .locator(joinAlt(Selectors.sources.addButton))
-      .first()
-      .click({ timeout: 5_000 });
-    await page
-      .locator(Selectors.sources.overlayPane)
-      .first()
-      .waitFor({ state: "visible", timeout: 8_000 });
+    await page.locator(joinAlt(Selectors.sources.addButton)).first().click({ timeout: 5_000 });
+    await waitForAddSourceUi(page, 8_000);
     return;
   } catch (err) {
-    log.warning(`  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`);
+    log.warning(
+      `  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`
+    );
   }
 
   // URL fallback — useful when the sidebar button is hidden or covered.
@@ -212,30 +210,57 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
     const u = new URL(url);
     u.searchParams.set("addSource", "true");
     await page.goto(u.toString(), { waitUntil: "domcontentloaded", timeout: 15_000 });
-    await page
-      .locator(Selectors.sources.overlayPane)
-      .first()
-      .waitFor({ state: "visible", timeout: 10_000 });
+    await waitForAddSourceUi(page, 10_000);
     return;
   }
 
   throw new Error('Could not open the "Add source" dialog');
 }
 
-async function isOverlayVisible(page: Page): Promise<boolean> {
-  return page
+async function isAddSourceUiVisible(page: Page): Promise<boolean> {
+  const overlayVisible = await page
     .locator(Selectors.sources.overlayPane)
+    .first()
+    .isVisible({ timeout: 500 })
+    .catch(() => false);
+  if (overlayVisible) return true;
+
+  return page
+    .locator(joinAlt(Selectors.sources.sourcePickerReady))
     .first()
     .isVisible({ timeout: 500 })
     .catch(() => false);
 }
 
+async function waitForAddSourceUi(page: Page, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isAddSourceUiVisible(page)) return;
+    await safeSleep(page, 300);
+  }
+  throw new Error('Could not open the "Add source" dialog');
+}
+
+async function ensureSourcesPanel(page: Page): Promise<void> {
+  const sourcesTab = page.locator(joinAlt(Selectors.tabs.sources)).first();
+  if (await sourcesTab.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await sourcesTab.click({ timeout: 5_000 }).catch(() => undefined);
+    await safeSleep(page, 500);
+  }
+}
+
+async function addSourceScope(page: Page): Promise<Locator> {
+  const overlay = page.locator(Selectors.sources.overlayPane).first();
+  if (await overlay.isVisible({ timeout: 500 }).catch(() => false)) return overlay;
+  return page.locator("body");
+}
+
 async function pickSourceType(page: Page, type: SourceType): Promise<void> {
   const candidates =
     type === "url" ? Selectors.sources.sourceTypeUrl : Selectors.sources.sourceTypeText;
-  const overlay = page.locator(Selectors.sources.overlayPane).first();
+  const scope = await addSourceScope(page);
   for (const sel of candidates) {
-    const target = overlay.locator(sel).first();
+    const target = scope.locator(sel).first();
     if (await target.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await target.click();
       // Sub-dialog needs a moment to hydrate before we type.
@@ -247,7 +272,7 @@ async function pickSourceType(page: Page, type: SourceType): Promise<void> {
 }
 
 async function fillSourceContent(page: Page, input: AddSourceInput): Promise<void> {
-  const overlay = page.locator(Selectors.sources.overlayPane).first();
+  const scope = await addSourceScope(page);
 
   // Wait for the overlay to actually contain a textarea (the picker swap is
   // animated, so a tight 500 ms wait beats a busy poll).
@@ -256,7 +281,12 @@ async function fillSourceContent(page: Page, input: AddSourceInput): Promise<voi
   const inputCandidates = [
     Selectors.sources.overlayTextarea,
     Selectors.sources.overlayInput,
+    'textarea[aria-label*="Pasted" i]',
+    'textarea[placeholder*="Paste text" i]',
+    'textarea[aria-label*="Enter URLs" i]',
+    'textarea[placeholder*="Paste any links" i]',
     `${Selectors.sources.overlayPane} textarea:not(.query-box-input):not(.query-box-textarea)`,
+    "textarea:not(.query-box-input):not(.query-box-textarea)",
   ];
 
   let target = null;
@@ -287,7 +317,7 @@ async function fillSourceContent(page: Page, input: AddSourceInput): Promise<voi
       `${Selectors.sources.overlayPane} input[type="text"]:not([readonly])`,
     ];
     for (const sel of titleSelectors) {
-      const candidate = overlay.locator(sel).first();
+      const candidate = scope.locator(sel).first();
       if (await candidate.isVisible({ timeout: 500 }).catch(() => false)) {
         await candidate.fill(input.title).catch(() => undefined);
         titleInputFound = true;
@@ -306,9 +336,9 @@ async function fillSourceContent(page: Page, input: AddSourceInput): Promise<voi
 }
 
 async function confirmInsert(page: Page): Promise<void> {
-  const overlay = page.locator(Selectors.sources.overlayPane).first();
+  const scope = await addSourceScope(page);
   for (const sel of Selectors.sources.insertConfirm) {
-    const btn = overlay.locator(sel).first();
+    const btn = scope.locator(sel).first();
     if (await btn.isVisible({ timeout: 1_000 }).catch(() => false)) {
       const disabled = await btn.isDisabled().catch(() => false);
       if (disabled) continue;

--- a/src/tools/definitions/ask-question.ts
+++ b/src/tools/definitions/ask-question.ts
@@ -152,8 +152,8 @@ export const askQuestionTool: Tool = {
         description:
           "How citations are returned alongside the answer:\n" +
           "  • `none` (default) — raw answer, no citation extraction (fastest)\n" +
-          "  • `footnotes` — answer plus a `Sources:` block, e.g. `[1] DocName — \"excerpt…\"`\n" +
-          "  • `inline` — `[N]` markers in the answer are replaced with `[N] (DocName: \"excerpt…\")`\n" +
+          '  • `footnotes` — answer plus a `Sources:` block, e.g. `[1] DocName — "excerpt…"`\n' +
+          '  • `inline` — `[N]` markers in the answer are replaced with `[N] (DocName: "excerpt…")`\n' +
           "  • `json` — answer text untouched; structured `sources` array on the response\n\n" +
           "Use `none` for snappy chat. Use `json` when downstream code needs to " +
           "process citations programmatically. Use `footnotes`/`inline` when " +

--- a/src/tools/definitions/notebook-management.ts
+++ b/src/tools/definitions/notebook-management.ts
@@ -126,9 +126,9 @@ export const notebookManagementTools: Tool[] = [
       "caller omits `notebook_id` / `notebook_url`.\n\n" +
       "When to call:\n" +
       "  • The user explicitly switches context (e.g. \"Let's work on " +
-      "React now\")\n" +
+      'React now")\n' +
       "  • Task obviously needs a different notebook than the current one — " +
-      "announce the switch (\"Switching to the React notebook…\") before " +
+      'announce the switch ("Switching to the React notebook…") before ' +
       "calling.\n" +
       "  • If the right notebook is ambiguous, ask the user first instead " +
       "of guessing.",
@@ -235,8 +235,8 @@ export const notebookManagementTools: Tool[] = [
       "Search the library by free-text query — matches against `name`, " +
       "`description`, `topics`, and `tags`. Returns notebook objects with " +
       "their `id` so you can chain into `select_notebook` etc.\n\n" +
-      "Use this when the user references a notebook by topic (\"the React " +
-      "one\") instead of by exact name. If multiple notebooks match, " +
+      'Use this when the user references a notebook by topic ("the React ' +
+      'one") instead of by exact name. If multiple notebooks match, ' +
       "propose the top 1–2 and let the user choose.",
     inputSchema: {
       type: "object",
@@ -260,7 +260,7 @@ export const notebookManagementTools: Tool[] = [
       "Aggregate statistics about the local notebook library: " +
       "`total_notebooks`, `active_notebook` (id), `most_used_notebook`, " +
       "`total_queries`, `last_modified`. Useful as a quick health check or " +
-      "when the user asks \"what notebooks do I have?\".",
+      'when the user asks "what notebooks do I have?".',
     inputSchema: {
       type: "object",
       properties: {},

--- a/src/tools/definitions/sources.ts
+++ b/src/tools/definitions/sources.ts
@@ -46,7 +46,7 @@ export const addSourceTool: Tool = {
     "subsequent `ask_question` calls then have the new source in context. " +
     "Free notebooks cap at 50 sources.\n\n" +
     "Known quirk: pasted-text uploads occasionally redirect to a freshly " +
-    "created \"Untitled notebook\" on Google's side. The tool detects this " +
+    'created "Untitled notebook" on Google\'s side. The tool detects this ' +
     "and returns a clear error so you can re-try against the correct URL.",
   inputSchema: {
     type: "object",
@@ -94,10 +94,10 @@ export const generateAudioTool: Tool = {
   description:
     "Trigger podcast-style Audio Overview generation for a notebook.\n\n" +
     "**Async by default** — returns immediately with one of:\n" +
-    "  • `status: \"started\"` — generation just kicked off\n" +
-    "  • `status: \"in_progress\"` — a generation was already running; " +
+    '  • `status: "started"` — generation just kicked off\n' +
+    '  • `status: "in_progress"` — a generation was already running; ' +
     "this call attached to it\n" +
-    "  • `status: \"ready\"` (with `alreadyExisted: true`) — an Audio " +
+    '  • `status: "ready"` (with `alreadyExisted: true`) — an Audio ' +
     "Overview already existed; nothing was triggered\n\n" +
     "Generation typically takes 2–10 minutes. **Workflow:**\n" +
     "  1. `generate_audio` → returns immediately\n" +
@@ -113,9 +113,9 @@ export const generateAudioTool: Tool = {
       custom_prompt: {
         type: "string",
         description:
-          "Optional focus prompt for the Audio Overview, e.g. \"Focus on the " +
-          "API authentication flow and skip pricing\". Passed into the " +
-          "NotebookLM \"Customize\" sub-dialog before generation starts.",
+          'Optional focus prompt for the Audio Overview, e.g. "Focus on the ' +
+          'API authentication flow and skip pricing". Passed into the ' +
+          'NotebookLM "Customize" sub-dialog before generation starts.',
       },
       wait_for_completion: {
         type: "boolean",
@@ -178,7 +178,7 @@ export const downloadAudioTool: Tool = {
   name: "download_audio",
   description:
     "Save the completed Audio Overview to disk as a `.m4a` file. **Pre-" +
-    "condition:** `get_audio_status` must report `status: \"ready\"`. " +
+    'condition:** `get_audio_status` must report `status: "ready"`. ' +
     "Calling this before generation completes returns an error message " +
     "explaining what to do.\n\n" +
     "The file lands in `destination_dir` with NotebookLM's suggested " +

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -1029,9 +1029,7 @@ export class ToolHandlers {
       // `started` and `in_progress` count as success — the generation is on
       // its way; the caller polls `get_audio_status` for completion.
       const ok =
-        result.status === "ready" ||
-        result.status === "started" ||
-        result.status === "in_progress";
+        result.status === "ready" || result.status === "started" || result.status === "in_progress";
       return { success: ok, data: { result } };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- recognize the current Add sources picker as a valid add-source UI, not only role=dialog
- support plural Add sources button labels and source-menu readiness checks
- keep fill and submit selectors scoped to the dialog when present, with body fallback for menu-style layouts
- apply Prettier to files required for npm run check

## Verification
- npm ci
- npm run check

Note: lint reports one existing warning in src/transport/http.ts, but npm run check exits 0.