### PR TITLE
Fix NotebookLM add-source dialog selectors

### DIFF
--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -135,12 +135,20 @@ export const Selectors = {
       'button[aria-label*="ソースを追加" i]',
     ],
     /**
-     * Real Material modal. `[role="dialog"]` is set by Angular synchronously
-     * the moment the modal mounts — race-free against the `.mdc-dialog--open`
-     * animation class and resistant to Material-UI version bumps. Avoid
-     * `.cdk-overlay-pane` (matches every dropdown / emoji picker / menu).
+     * Real Material add-source modal. The generic `[role="dialog"]` selector
+     * can match unrelated overlays, so anchor to visible add-source states:
+     * the initial picker, the URL entry dialog, or stable text shown in the
+     * source picker. Avoid `.cdk-overlay-pane` (matches every dropdown / menu).
      */
-    overlayPane: '[role="dialog"]',
+    overlayPane:
+      '[role="dialog"]:visible:has(button.drop-zone-icon-button), ' +
+      '[role="dialog"]:visible:has(textarea[aria-label="Enter URLs"]), ' +
+      '[role="dialog"]:visible:has-text("Website and YouTube URLs"), ' +
+      '[role="dialog"]:visible:has-text("Paste any links"), ' +
+      '[role="dialog"]:visible:has-text("Upload files"), ' +
+      '[role="dialog"]:visible:has-text("Websites"), ' +
+      '[role="dialog"]:visible:has-text("Copied text"), ' +
+      '[role="dialog"]:visible:has-text("or drop your files")',
     overlayInput: '[role="dialog"] input[type="text"]:not([readonly])',
     overlayTextarea: '[role="dialog"] textarea',
     /**
@@ -201,6 +209,9 @@ export const Selectors = {
      */
     insertConfirm: [
       // Class-anchored (language-free).
+      'button[mat-flat-button]:has-text("Insert")',
+      'button.mdc-button--unelevated:has-text("Insert")',
+      'button.mat-mdc-unelevated-button:has-text("Insert")',
       'button.mdc-button--raised:has-text("Insert")',
       'button.mat-flat-button:has-text("Insert")',
       'button[color="primary"]:has-text("Insert")',
@@ -313,7 +324,7 @@ export const Selectors = {
      * contains the Download item.
      */
     audioMoreMenuButton: [
-      "artifact-library-item button:has(mat-icon:text-is(\"more_vert\"))",
+      'artifact-library-item button:has(mat-icon:text-is("more_vert"))',
       'artifact-library-item button[aria-label*="mehr" i]',
       'artifact-library-item button[aria-label*="more" i]',
       'artifact-library-item button[aria-label*="plus" i]',


### PR DESCRIPTION
## Summary
- narrow the add-source dialog selector so it targets visible NotebookLM source dialogs instead of any generic `[role="dialog"]` overlay
- add current Material unelevated/flat Insert button selectors used by the NotebookLM URL source flow
- keep the change scoped to source selector definitions

## Verification
- `npx prettier --check src/notebooklm/selectors.ts`
- `npx eslint src/notebooklm/selectors.ts`
- `npm run build`

Note: `npm run check` currently fails before lint/build because Prettier reports existing formatting issues in several untouched files (`src/notebooklm/sources.ts`, `src/tools/definitions/ask-question.ts`, `src/tools/definitions/notebook-management.ts`, `src/tools/definitions/sources.ts`, `src/tools/handlers.ts`).

## Local functional proof
The same selector changes were applied locally to a vendored v2.0.0 connector and verified against NotebookLM: `add_source` increased source count from 12 to 13, and `ask_question` returned success.