### PR TITLE
feat: add create_notebook and delete_notebook tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,30 @@ class NotebookLMMCPServer {
             );
             break;
 
+          case "create_notebook":
+            result = await this.toolHandlers.handleCreateNotebook(
+              args as {
+                source: { type: "url" | "text"; content: string; title?: string };
+                name: string;
+                description?: string;
+                topics?: string[];
+                use_cases?: string[];
+                set_active?: boolean;
+                show_browser?: boolean;
+              }
+            );
+            break;
+
+          case "delete_notebook":
+            result = await this.toolHandlers.handleDeleteNotebook(
+              args as {
+                title?: string;
+                notebook_id?: string;
+                show_browser?: boolean;
+              }
+            );
+            break;
+
           case "add_notebook":
             result = await this.toolHandlers.handleAddNotebook(
               args as {

--- a/src/notebooklm/notebooks.ts
+++ b/src/notebooklm/notebooks.ts
@@ -1,0 +1,146 @@
+/**
+ * Notebook-level operations that live on the NotebookLM *home* page rather
+ * than inside a single notebook — currently just deletion.
+ *
+ * Deletion is only reachable from the home list: each row exposes an actions
+ * menu (`Selectors.notebooks.actionsMenuTrigger`) whose "Delete" item opens a
+ * confirm dialog ("Excluir o notebook de todos os lugares?" · buttons
+ * Cancel / Delete). Verified live 2026-07.
+ *
+ * The home DOM exposes NO notebook UUID and no per-row link, so the only
+ * stable handle is the visible TITLE. Because deletion is destructive we
+ * match the title EXACTLY and refuse unless exactly one row matches.
+ */
+
+import type { Page } from "patchright";
+import { Selectors, joinAlt } from "./selectors.js";
+import { safeSleep, isRecoverable } from "../browser/watchdog.js";
+import { log } from "../utils/logger.js";
+
+const NOTEBOOKLM_HOME = "https://notebooklm.google.com/";
+const CANCEL_RE = /cancel|cancelar|abbrechen|annuler|annulla|cancelar|キャンセル/i;
+
+export interface DeleteNotebookResult {
+  success: boolean;
+  deletedTitle?: string;
+  message?: string;
+}
+
+export async function deleteNotebookByTitle(
+  page: Page,
+  title: string
+): Promise<DeleteNotebookResult> {
+  log.info(`🗑️  [delete_notebook] target title="${title}"`);
+  try {
+    // 1. Ensure we are on the home list (deletion lives there, not inside a
+    //    notebook).
+    const url = page.url();
+    if (!url.includes("notebooklm.google.com") || url.includes("/notebook/")) {
+      await page.goto(NOTEBOOKLM_HOME, { waitUntil: "domcontentloaded", timeout: 30_000 });
+    }
+    await page
+      .locator(joinAlt(Selectors.notebooks.createButton))
+      .first()
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .catch(() => undefined);
+    await safeSleep(page, 1_500);
+
+    // 2. Locate the row by title (substring match — the home title may carry a
+    //    leading emoji or be truncated). Uniqueness-guarded: never guess for a
+    //    destructive op.
+    const titleLoc = page.getByText(title, { exact: false });
+    const count = await titleLoc.count();
+    if (count === 0) {
+      return {
+        success: false,
+        message:
+          `No notebook whose title contains "${title}" was found on the home ` +
+          `page. Match is against the NotebookLM title, which may differ from ` +
+          `the library name if it was auto-generated.`,
+      };
+    }
+    if (count > 1) {
+      return {
+        success: false,
+        message:
+          `Ambiguous: ${count} notebooks have a title containing "${title}". ` +
+          `Refusing to delete — pass a more specific title, or rename to ` +
+          `disambiguate, then retry.`,
+      };
+    }
+
+    // 3. From the title node, reach the row's actions-menu trigger (nearest
+    //    ancestor that contains a mat menu trigger).
+    const trigger = titleLoc
+      .locator(
+        'xpath=ancestor::*[.//button[contains(@class,"mat-mdc-menu-trigger")]][1]' +
+          '//button[contains(@class,"mat-mdc-menu-trigger")]'
+      )
+      .first();
+    await trigger.scrollIntoViewIfNeeded().catch(() => undefined);
+    await trigger.click();
+    await safeSleep(page, 600);
+
+    // 4. Click the "Delete" menu item.
+    let clickedDelete = false;
+    for (const sel of Selectors.notebooks.deleteButton) {
+      const item = page.locator(sel).first();
+      if (await item.isVisible({ timeout: 800 }).catch(() => false)) {
+        await item.click();
+        clickedDelete = true;
+        break;
+      }
+    }
+    if (!clickedDelete) {
+      await page.keyboard.press("Escape").catch(() => undefined);
+      return {
+        success: false,
+        message: "Opened the card menu but could not find the Delete item.",
+      };
+    }
+    await safeSleep(page, 600);
+
+    // 5. Confirm — click the primary (non-cancel) button in the confirm dialog.
+    const dialog = page.locator('[role="dialog"].mat-mdc-dialog-container').first();
+    await dialog.waitFor({ state: "visible", timeout: 8_000 }).catch(() => undefined);
+    let confirmed = false;
+    for (const sel of Selectors.notebooks.confirmDelete) {
+      const btn = dialog.locator(sel).first();
+      if (await btn.isVisible({ timeout: 800 }).catch(() => false)) {
+        const txt = ((await btn.textContent().catch(() => "")) || "").trim();
+        if (CANCEL_RE.test(txt)) continue;
+        await btn.click();
+        confirmed = true;
+        break;
+      }
+    }
+    if (!confirmed) {
+      await page.keyboard.press("Escape").catch(() => undefined);
+      return {
+        success: false,
+        message: "Delete confirmation dialog appeared but no confirm button matched.",
+      };
+    }
+
+    // 6. Verify: the dialog closes and the title vanishes from the list.
+    await dialog.waitFor({ state: "hidden", timeout: 15_000 }).catch(() => undefined);
+    await safeSleep(page, 1_500);
+    const stillThere = await page.getByText(title, { exact: false }).count();
+    if (stillThere > 0) {
+      return {
+        success: false,
+        deletedTitle: title,
+        message:
+          "Clicked confirm but the notebook still appears in the list — " +
+          "deletion may not have completed.",
+      };
+    }
+
+    log.success(`  ✅ Notebook "${title}" deleted from NotebookLM`);
+    return { success: true, deletedTitle: title };
+  } catch (err) {
+    if (isRecoverable(err)) throw err;
+    log.warning(`  ⚠️  delete_notebook failed: ${err}`);
+    return { success: false, message: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -139,10 +139,15 @@ export const Selectors = {
      * the moment the modal mounts — race-free against the `.mdc-dialog--open`
      * animation class and resistant to Material-UI version bumps. Avoid
      * `.cdk-overlay-pane` (matches every dropdown / emoji picker / menu).
+     *
+     * We qualify with `.mat-mdc-dialog-container` so `.first()` never lands on
+     * a stray `[role="dialog"]` — on a freshly-created notebook the cover UI
+     * mounts a hidden `emoji-keyboard` dialog *before* the real add-source
+     * dialog in DOM order, which would otherwise shadow it.
      */
-    overlayPane: '[role="dialog"]',
-    overlayInput: '[role="dialog"] input[type="text"]:not([readonly])',
-    overlayTextarea: '[role="dialog"] textarea',
+    overlayPane: '[role="dialog"].mat-mdc-dialog-container',
+    overlayInput: '[role="dialog"].mat-mdc-dialog-container input[type="text"]:not([readonly])',
+    overlayTextarea: '[role="dialog"].mat-mdc-dialog-container textarea',
     /**
      * Source-type buttons in the Add-source overlay. Google ships them
      * *without* aria-labels — the only stable, language-agnostic anchor is
@@ -313,7 +318,7 @@ export const Selectors = {
      * contains the Download item.
      */
     audioMoreMenuButton: [
-      "artifact-library-item button:has(mat-icon:text-is(\"more_vert\"))",
+      'artifact-library-item button:has(mat-icon:text-is("more_vert"))',
       'artifact-library-item button[aria-label*="mehr" i]',
       'artifact-library-item button[aria-label*="more" i]',
       'artifact-library-item button[aria-label*="plus" i]',
@@ -341,6 +346,29 @@ export const Selectors = {
 
   notebooks: {
     projectCard: 'button[aria-labelledby*="project-"]',
+    /**
+     * "Create new" / "Criar novo" button on the NotebookLM home page. The
+     * project never created notebooks before, so these anchors are new: the
+     * class `.create-new-button` is the language-agnostic primary path, with
+     * aria-label + visible-text fallbacks for the eight major locales.
+     */
+    createButton: [
+      "button.create-new-button",
+      "button.create-new-label-button",
+      'button[aria-label*="create new" i]',
+      'button[aria-label*="new notebook" i]',
+      'button[aria-label*="neues notebook" i]',
+      'button[aria-label*="novo notebook" i]',
+      'button:has-text("Create new")',
+      'button:has-text("Criar")',
+      'button:has-text("Novo")',
+      'button:has-text("Neu erstellen")',
+      'button:has-text("Créer")',
+      'button:has-text("Crear")',
+      'button:has-text("Crea")',
+      'button:has-text("Nieuw")',
+      'button:has-text("新規作成")',
+    ],
     cardMenuButton: [
       'button[aria-label*="menu" i]',
       'button[aria-label*="options" i]',
@@ -351,7 +379,19 @@ export const Selectors = {
       'button[aria-label*="opções" i]',
       'button[aria-label*="メニュー" i]',
     ],
+    /**
+     * The per-row "actions" menu trigger on the home list (verified live):
+     * `<button class="mat-mdc-menu-trigger project-button-more-menu-button"
+     * aria-label="Menu de ações do projeto">`. Used to open the card menu that
+     * holds Delete/Rename/Pin. Anchored on class first (language-free).
+     */
+    actionsMenuTrigger: [
+      "button.project-button-more-menu-button",
+      'button.mat-mdc-menu-trigger[aria-label*="ações do projeto" i]',
+      'button.mat-mdc-menu-trigger[aria-label*="project actions" i]',
+    ],
     deleteButton: [
+      '[role="menuitem"]:has(mat-icon:text-is("delete"))',
       '[role="menuitem"]:has-text("Delete")',
       '[role="menuitem"]:has-text("Löschen")',
       '[role="menuitem"]:has-text("Supprimer")',

--- a/src/notebooklm/sources.ts
+++ b/src/notebooklm/sources.ts
@@ -50,6 +50,24 @@ export interface AddSourceResult {
   message?: string;
 }
 
+export interface CreateNotebookInput {
+  /** First source — NotebookLM cannot create an empty notebook. */
+  source: AddSourceInput;
+}
+
+export interface CreateNotebookResult {
+  success: boolean;
+  /** UUID of the freshly-created notebook (from the resulting URL). */
+  notebookId?: string;
+  /** Full NotebookLM URL of the new notebook. */
+  notebookUrl?: string;
+  /** Outcome of ingesting the mandatory first source. */
+  source?: AddSourceResult;
+  message?: string;
+}
+
+const NOTEBOOKLM_HOME = "https://notebooklm.google.com/";
+
 export async function addSource(page: Page, input: AddSourceInput): Promise<AddSourceResult> {
   const initialUrl = page.url();
   const expectedUuid = initialUrl.match(/notebook\/([a-f0-9-]+)/)?.[1];
@@ -86,9 +104,7 @@ export async function addSource(page: Page, input: AddSourceInput): Promise<AddS
       const currentUrl = page.url();
       const currentUuid = currentUrl.match(/notebook\/([a-f0-9-]+)/)?.[1];
       if (currentUuid && currentUuid !== expectedUuid) {
-        log.error(
-          `  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`
-        );
+        log.error(`  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`);
         return {
           success: false,
           type: input.type,
@@ -136,6 +152,107 @@ export async function addSource(page: Page, input: AddSourceInput): Promise<AddS
       type: input.type,
       sourceCountBefore: 0,
       sourceCountAfter: 0,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Create a brand-new NotebookLM notebook, seeded with a mandatory first
+ * source. NotebookLM has no "empty notebook" concept — creation is coupled to
+ * the first source. Flow:
+ *   1. Go to the home page and click "Create new".
+ *   2. NotebookLM navigates to a fresh `/notebook/<uuid>` and auto-opens the
+ *      Add-source overlay. We capture the new UUID from the URL.
+ *   3. Reuse the add_source overlay helpers to ingest the first source.
+ */
+export async function createNotebook(
+  page: Page,
+  input: CreateNotebookInput
+): Promise<CreateNotebookResult> {
+  log.info(`🆕 [create_notebook] seeding with a ${input.source.type} source`);
+  try {
+    // 1. Ensure we are on the home page (the create button lives there, not
+    //    inside an existing notebook).
+    const url = page.url();
+    if (!url.includes("notebooklm.google.com") || url.includes("/notebook/")) {
+      await page.goto(NOTEBOOKLM_HOME, { waitUntil: "domcontentloaded", timeout: 30_000 });
+      await safeSleep(page, 1_500);
+    }
+
+    // 2. Click "Create new".
+    const createBtn = page.locator(joinAlt(Selectors.notebooks.createButton)).first();
+    await createBtn.waitFor({ state: "visible", timeout: 15_000 });
+    await createBtn.click();
+    log.info("  ✅ Create button clicked");
+
+    // 3. Wait for the redirect to the fresh notebook and capture its UUID.
+    //    Require a *full* UUID — the transient `/notebook/create` URL would
+    //    otherwise match a short prefix like "c".
+    const UUID_RE = /notebook\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/;
+    let newUuid: string | undefined;
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      newUuid = page.url().match(UUID_RE)?.[1];
+      if (newUuid) break;
+      await safeSleep(page, 500);
+    }
+    if (!newUuid) {
+      return {
+        success: false,
+        message:
+          "Clicked Create but NotebookLM did not navigate to a new " +
+          "/notebook/<uuid> within 30 s. The home-page create-button selector " +
+          "may have changed — please verify Selectors.notebooks.createButton.",
+      };
+    }
+    const notebookUrl = `${NOTEBOOKLM_HOME}notebook/${newUuid}`;
+    log.success(`  ✅ New notebook created: ${newUuid}`);
+
+    // 4. Ingest the mandatory first source, reusing the add_source overlay
+    //    helpers. A fresh notebook auto-opens the picker (URL gains
+    //    `?addSource=true`); wait for the real dialog to mount, then let
+    //    openAddSourceOverlay detect the already-open dialog and reuse it.
+    await page
+      .locator(Selectors.sources.overlayPane)
+      .first()
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .catch(() => undefined);
+    await openAddSourceOverlay(page);
+    await pickSourceType(page, input.source.type);
+    await fillSourceContent(page, input.source);
+    const before = await countSources(page);
+    await confirmInsert(page);
+    await waitForOverlayToClose(page);
+    const after = await waitForSourceCountIncrease(page, before, 90_000);
+
+    const sourceOk = after > before;
+    const sourceResult: AddSourceResult = {
+      success: sourceOk,
+      type: input.source.type,
+      sourceCountBefore: before,
+      sourceCountAfter: after,
+      message: sourceOk
+        ? undefined
+        : (await readDialogError(page)) ||
+          "Notebook was created but the first source did not appear within 90 s " +
+            "(NotebookLM may still be indexing).",
+    };
+
+    return {
+      success: sourceOk,
+      notebookId: newUuid,
+      notebookUrl,
+      source: sourceResult,
+      message: sourceOk
+        ? undefined
+        : "Notebook created, but seeding the first source failed — see `source.message`.",
+    };
+  } catch (err) {
+    if (isRecoverable(err)) throw err;
+    log.warning(`  ⚠️  create_notebook failed: ${err}`);
+    return {
+      success: false,
       message: err instanceof Error ? err.message : String(err),
     };
   }
@@ -193,17 +310,16 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
 
   // Try the sidebar button first — fastest path on a populated notebook.
   try {
-    await page
-      .locator(joinAlt(Selectors.sources.addButton))
-      .first()
-      .click({ timeout: 5_000 });
+    await page.locator(joinAlt(Selectors.sources.addButton)).first().click({ timeout: 5_000 });
     await page
       .locator(Selectors.sources.overlayPane)
       .first()
       .waitFor({ state: "visible", timeout: 8_000 });
     return;
   } catch (err) {
-    log.warning(`  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`);
+    log.warning(
+      `  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`
+    );
   }
 
   // URL fallback — useful when the sidebar button is hidden or covered.

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -26,8 +26,11 @@ import {
 } from "../notebooklm/citations.js";
 import {
   addSource as addSourceToPage,
+  createNotebook as createNotebookOnPage,
   type AddSourceInput,
   type AddSourceResult,
+  type CreateNotebookInput,
+  type CreateNotebookResult,
 } from "../notebooklm/sources.js";
 import {
   generateAudioOverview as generateAudioOnPage,
@@ -37,6 +40,11 @@ import {
   type AudioGenerationResult,
   type DownloadAudioResult,
 } from "../notebooklm/audio.js";
+import {
+  deleteNotebookByTitle as deleteNotebookOnPage,
+  type DeleteNotebookResult,
+} from "../notebooklm/notebooks.js";
+import { Selectors, joinAlt } from "../notebooklm/selectors.js";
 import { CONFIG } from "../config.js";
 import { log } from "../utils/logger.js";
 import type { SessionInfo, ProgressCallback } from "../types.js";
@@ -169,9 +177,38 @@ export class BrowserSession {
    *
    * Based on Python _wait_for_ready() from browser_session.py:104-113
    */
+  /**
+   * A session whose URL is the NotebookLM home (no `/notebook/` segment) is a
+   * "home-mode" session, used only to create a new notebook. Its readiness
+   * signal is the "Create new" button, not the per-notebook chat input.
+   */
+  private isHomeMode(): boolean {
+    return !this.notebookUrl.includes("/notebook/");
+  }
+
   private async waitForNotebookLMReady(): Promise<void> {
     if (!this.page) {
       throw new Error("Page not initialized");
+    }
+
+    // Home-mode: wait for the "Create new" button instead of the chat input.
+    if (this.isHomeMode()) {
+      log.info("  ⏳ Home mode — waiting for the Create button...");
+      try {
+        await this.page.waitForSelector(joinAlt(Selectors.notebooks.createButton), {
+          timeout: 15000,
+          state: "visible",
+        });
+        log.success("  ✅ Home page ready (Create button visible)!");
+      } catch (error) {
+        log.error(`  ❌ NotebookLM home not ready: ${error}`);
+        throw new Error(
+          "Could not find the NotebookLM 'Create new' button on the home page. " +
+            "The selector may have changed — verify Selectors.notebooks.createButton.",
+          { cause: error }
+        );
+      }
+      return;
     }
 
     try {
@@ -491,6 +528,20 @@ export class BrowserSession {
       await this.init();
     }
     return await addSourceToPage(this.page!, input);
+  }
+
+  async createNotebook(input: CreateNotebookInput): Promise<CreateNotebookResult> {
+    if (!this.initialized || !this.page || this.isPageClosedSafe()) {
+      await this.init();
+    }
+    return await createNotebookOnPage(this.page!, input);
+  }
+
+  async deleteNotebook(title: string): Promise<DeleteNotebookResult> {
+    if (!this.initialized || !this.page || this.isPageClosedSafe()) {
+      await this.init();
+    }
+    return await deleteNotebookOnPage(this.page!, title);
   }
 
   /**

--- a/src/tools/definitions/notebook-management.ts
+++ b/src/tools/definitions/notebook-management.ts
@@ -8,6 +8,135 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
  */
 export const notebookManagementTools: Tool[] = [
   {
+    name: "create_notebook",
+    description:
+      "Create a BRAND-NEW NotebookLM notebook from scratch and seed it with a " +
+      "mandatory first source, then auto-register it in the local library.\n\n" +
+      "NotebookLM has no empty-notebook concept — a notebook is born together " +
+      "with its first source, so `source` is REQUIRED:\n" +
+      '  • `source.type = "url"` — NotebookLM crawls and indexes a website\n' +
+      '  • `source.type = "text"` — the raw text is ingested as a document\n\n' +
+      "On success returns `notebookId` (the new UUID), `notebookUrl`, and the " +
+      "first-source result. The notebook is registered in the library using " +
+      "the supplied `name`/`description`/`topics`, so subsequent tools can " +
+      "target it by `notebook_id`. Add more sources afterwards with " +
+      "`add_source`.\n\n" +
+      "Distinct from `add_notebook`, which only REGISTERS an already-existing " +
+      "notebook by its share URL. Free-tier limits: 100 notebooks · 50 " +
+      "sources each · 50 queries/day.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source: {
+          type: "object",
+          description: "The mandatory first source the notebook is created around.",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["url", "text"],
+              description:
+                "`url` crawls the supplied website; `text` ingests `content` " +
+                "verbatim as a copied document.",
+            },
+            content: {
+              type: "string",
+              description:
+                "When `type=url`: a fully-qualified URL (https://…). " +
+                "When `type=text`: the raw text body.",
+            },
+            title: {
+              type: "string",
+              description: "Optional display title for the source (recommended for text).",
+            },
+          },
+          required: ["type", "content"],
+        },
+        name: {
+          type: "string",
+          description:
+            "Display name for the new notebook in the local library " + "(e.g. 'Contratos 2026').",
+        },
+        description: {
+          type: "string",
+          description: "1–2 sentence summary of what the notebook will contain.",
+        },
+        topics: {
+          type: "array",
+          items: { type: "string" },
+          description: "3–5 topics covered. Used by `search_notebooks`.",
+        },
+        use_cases: {
+          type: "array",
+          items: { type: "string" },
+          description: "When this notebook should be consulted.",
+        },
+        set_active: {
+          type: "boolean",
+          description:
+            "If true (default), make the new notebook the active one so later " +
+            "tools default to it without needing `notebook_id`.",
+        },
+        show_browser: {
+          type: "boolean",
+          description: "Show the browser window for debugging. Default: false.",
+        },
+      },
+      required: ["source", "name"],
+    },
+    annotations: {
+      title: "Create new notebook",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: "delete_notebook",
+    description:
+      "PERMANENTLY delete a notebook on the NotebookLM (Google) side — it is " +
+      "removed from all locations and cannot be recovered — then drop it from " +
+      "the local library.\n\n" +
+      "Distinct from `remove_notebook`, which only unregisters the notebook " +
+      "locally and leaves it intact on Google.\n\n" +
+      "Targeting: NotebookLM's home list exposes no notebook UUID, so the " +
+      "notebook is matched by a substring of its visible title. Because this " +
+      "is destructive, deletion is refused unless exactly one notebook matches " +
+      "(zero → not found; more than one → ambiguous, pass a longer title). " +
+      "Pass `notebook_id` to " +
+      "also clean up the matching library entry (its library name is used as " +
+      "the title when `title` is omitted). NOTE: a notebook's NotebookLM title " +
+      "may differ from its library name if the title was auto-generated — in " +
+      "that case pass the exact `title` as shown in NotebookLM.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Exact title of the notebook as shown on the NotebookLM home page.",
+        },
+        notebook_id: {
+          type: "string",
+          description:
+            "Library notebook id. Its stored name is used as the title when " +
+            "`title` is omitted, and the local library entry is removed on " +
+            "successful deletion.",
+        },
+        show_browser: {
+          type: "boolean",
+          description: "Show the browser window for debugging. Default: false.",
+        },
+      },
+    },
+    annotations: {
+      title: "Delete notebook (permanent)",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  {
     name: "add_notebook",
     description:
       "Register a NotebookLM notebook in the local library so it can be " +
@@ -126,9 +255,9 @@ export const notebookManagementTools: Tool[] = [
       "caller omits `notebook_id` / `notebook_url`.\n\n" +
       "When to call:\n" +
       "  • The user explicitly switches context (e.g. \"Let's work on " +
-      "React now\")\n" +
+      'React now")\n' +
       "  • Task obviously needs a different notebook than the current one — " +
-      "announce the switch (\"Switching to the React notebook…\") before " +
+      'announce the switch ("Switching to the React notebook…") before ' +
       "calling.\n" +
       "  • If the right notebook is ambiguous, ask the user first instead " +
       "of guessing.",
@@ -235,8 +364,8 @@ export const notebookManagementTools: Tool[] = [
       "Search the library by free-text query — matches against `name`, " +
       "`description`, `topics`, and `tags`. Returns notebook objects with " +
       "their `id` so you can chain into `select_notebook` etc.\n\n" +
-      "Use this when the user references a notebook by topic (\"the React " +
-      "one\") instead of by exact name. If multiple notebooks match, " +
+      'Use this when the user references a notebook by topic ("the React ' +
+      'one") instead of by exact name. If multiple notebooks match, ' +
       "propose the top 1–2 and let the user choose.",
     inputSchema: {
       type: "object",
@@ -260,7 +389,7 @@ export const notebookManagementTools: Tool[] = [
       "Aggregate statistics about the local notebook library: " +
       "`total_notebooks`, `active_notebook` (id), `most_used_notebook`, " +
       "`total_queries`, `last_modified`. Useful as a quick health check or " +
-      "when the user asks \"what notebooks do I have?\".",
+      'when the user asks "what notebooks do I have?".',
     inputSchema: {
       type: "object",
       properties: {},

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -13,7 +13,8 @@ import type {
   NotebookEntry,
   UpdateNotebookInput,
 } from "../library/types.js";
-import type { AddSourceResult } from "../notebooklm/sources.js";
+import type { AddSourceResult, CreateNotebookResult } from "../notebooklm/sources.js";
+import type { DeleteNotebookResult } from "../notebooklm/notebooks.js";
 import type { AudioGenerationResult, DownloadAudioResult } from "../notebooklm/audio.js";
 import { CONFIG, applyBrowserOptions, type BrowserOptions } from "../config.js";
 import { log } from "../utils/logger.js";
@@ -956,6 +957,129 @@ export class ToolHandlers {
   }
 
   /**
+   * Handle create_notebook tool — create a fresh notebook seeded with a first
+   * source, then auto-register it in the local library.
+   */
+  async handleCreateNotebook(args: {
+    source: { type: "url" | "text"; content: string; title?: string };
+    name: string;
+    description?: string;
+    topics?: string[];
+    use_cases?: string[];
+    set_active?: boolean;
+    show_browser?: boolean;
+  }): Promise<ToolResult<{ result: CreateNotebookResult; notebook?: NotebookEntry }>> {
+    log.info(`🔧 [TOOL] create_notebook called (name="${args.name}")`);
+    const originalConfig = { ...CONFIG };
+    if (args.show_browser !== undefined) {
+      const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
+      Object.assign(CONFIG, effectiveConfig);
+    }
+    const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
+    try {
+      // A home-mode session (URL without /notebook/) so init() waits for the
+      // "Create new" button instead of a per-notebook chat input.
+      const session = await this.sessionManager.getOrCreateSession(
+        undefined,
+        "https://notebooklm.google.com/",
+        overrideHeadless
+      );
+      const result = await session.createNotebook({ source: args.source });
+
+      if (!result.success || !result.notebookUrl) {
+        return { success: false, data: { result }, error: result.message };
+      }
+
+      // Register the new notebook in the local library so later tools can
+      // target it by notebook_id.
+      const notebook = this.library.addNotebook({
+        url: result.notebookUrl,
+        name: args.name,
+        description: args.description || `Notebook criado em ${args.name}`,
+        topics: args.topics && args.topics.length > 0 ? args.topics : [args.name],
+        use_cases: args.use_cases,
+      });
+
+      if (args.set_active !== false) {
+        this.library.selectNotebook(notebook.id);
+      }
+
+      log.success(`✅ [TOOL] create_notebook completed: ${notebook.id} (${result.notebookId})`);
+      return { success: true, data: { result, notebook } };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error(`❌ [TOOL] create_notebook failed: ${msg}`);
+      return { success: false, error: msg };
+    } finally {
+      Object.assign(CONFIG, originalConfig);
+    }
+  }
+
+  /**
+   * Handle delete_notebook tool — permanently delete a notebook on the
+   * NotebookLM (Google) side, then drop it from the local library. Distinct
+   * from remove_notebook, which only unregisters it locally.
+   */
+  async handleDeleteNotebook(args: {
+    title?: string;
+    notebook_id?: string;
+    show_browser?: boolean;
+  }): Promise<ToolResult<{ result: DeleteNotebookResult; removed_from_library: boolean }>> {
+    log.info(
+      `🔧 [TOOL] delete_notebook called (title="${args.title ?? ""}" id="${args.notebook_id ?? ""}")`
+    );
+    const originalConfig = { ...CONFIG };
+    if (args.show_browser !== undefined) {
+      const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
+      Object.assign(CONFIG, effectiveConfig);
+    }
+    const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
+    try {
+      // Resolve the title to match on the home list, plus the library entry to
+      // clean up afterwards.
+      let title = args.title;
+      let libEntry = args.notebook_id ? this.library.getNotebook(args.notebook_id) : null;
+      if (!title && libEntry) title = libEntry.name;
+      if (!title) {
+        return {
+          success: false,
+          error:
+            "Provide `title` (the exact NotebookLM title) or a `notebook_id` " +
+            "whose library name matches the notebook's title.",
+        };
+      }
+      if (!libEntry) {
+        libEntry = this.library.listNotebooks().find((n) => n.name === title) ?? null;
+      }
+
+      const session = await this.sessionManager.getOrCreateSession(
+        undefined,
+        "https://notebooklm.google.com/",
+        overrideHeadless
+      );
+      const result = await session.deleteNotebook(title);
+
+      let removedFromLibrary = false;
+      if (result.success && libEntry) {
+        removedFromLibrary = this.library.removeNotebook(libEntry.id);
+        await this.sessionManager.closeSessionsForNotebook(libEntry.url).catch(() => 0);
+      }
+
+      return {
+        success: result.success,
+        data: { result, removed_from_library: removedFromLibrary },
+        ...(result.success ? {} : { error: result.message }),
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error(`❌ [TOOL] delete_notebook failed: ${msg}`);
+      return { success: false, error: msg };
+    } finally {
+      Object.assign(CONFIG, originalConfig);
+    }
+  }
+
+  /**
    * Handle add_source tool (issue #25).
    */
   async handleAddSource(args: {
@@ -1029,9 +1153,7 @@ export class ToolHandlers {
       // `started` and `in_progress` count as success — the generation is on
       // its way; the caller polls `get_audio_status` for completion.
       const ok =
-        result.status === "ready" ||
-        result.status === "started" ||
-        result.status === "in_progress";
+        result.status === "ready" || result.status === "started" || result.status === "in_progress";
       return { success: ok, data: { result } };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Adds two notebook-lifecycle tools that were missing: you could **register** a notebook (`add_notebook`) or **unregister it locally** (`remove_notebook`), but there was no way to **create** a new notebook or **delete** one on the Google side. Both are implemented by reusing the existing add-source overlay flow and the home-page card menu — no new dependencies.

### `create_notebook`
- Creates a fresh notebook from scratch, seeded with a **mandatory first source** (NotebookLM has no empty-notebook concept), and auto-registers it in the local library.
- Adds a **"home mode"** to `BrowserSession`: when the session URL has no `/notebook/` segment, readiness waits for the home **Create new** button instead of the per-notebook chat input.
- Reuses `openAddSourceOverlay` / `pickSourceType` / `fillSourceContent` / `confirmInsert`, then captures the new notebook UUID from the resulting URL.

### `delete_notebook`
- **Permanently** deletes a notebook on the NotebookLM (Google) side via the home-list card menu, then drops it from the local library. Distinct from `remove_notebook` (local-only).
- The home DOM exposes no notebook UUID, so it matches by a **title substring** and — being destructive — **refuses unless exactly one notebook matches** (zero → not found; more than one → ambiguous).

## Robustness fixes found while testing live
- **Fresh notebooks mount a hidden `emoji-keyboard` `[role="dialog"]`** *before* the real add-source dialog. `.first()` on `sources.overlayPane` landed on it. Qualified the selector with `.mat-mdc-dialog-container` so it always resolves to the real dialog — this also hardens the existing `add_source`.
- **Require a full UUID** when capturing the new notebook id; the transient `/notebook/create` URL otherwise matched a short prefix.

## Files
- `src/notebooklm/sources.ts` — `createNotebook()` + interfaces
- `src/notebooklm/notebooks.ts` — **new**, `deleteNotebookByTitle()`
- `src/notebooklm/selectors.ts` — home create button, actions-menu trigger, delete-item icon anchor, qualified `overlayPane`
- `src/session/browser-session.ts` — home mode + `createNotebook`/`deleteNotebook`
- `src/tools/definitions/notebook-management.ts` — tool schemas
- `src/tools/handlers.ts` — `handleCreateNotebook` / `handleDeleteNotebook`
- `src/index.ts` — dispatch cases

## Testing
Verified **end-to-end against the live NotebookLM UI** (system Chrome, real account):
- `create_notebook` → new notebook created, first source ingested (`sourceCountBefore: 0 → sourceCountAfter: 1`), library entry registered.
- `delete_notebook` → notebook deleted on Google side, row confirmed gone from the home list.
- `npm run build` clean; `prettier`/`eslint` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)