### PR TITLE
feat: add create_notebook tool for fresh notebook creation (#70)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,20 @@ class NotebookLMMCPServer {
             result = await this.toolHandlers.handleCleanupData(args as { confirm: boolean });
             break;
 
+          case "create_notebook":
+            result = await this.toolHandlers.handleCreateNotebook(
+              args as {
+                name?: string;
+                description?: string;
+                topics?: string[];
+                session_id?: string;
+                notebook_id?: string;
+                notebook_url?: string;
+                show_browser?: boolean;
+              }
+            );
+            break;
+
           case "add_source":
             result = await this.toolHandlers.handleAddSource(
               args as {

--- a/src/notebooklm/create-notebook.ts
+++ b/src/notebooklm/create-notebook.ts
@@ -1,0 +1,78 @@
+/**
+ * Create a brand-new NotebookLM notebook from the homepage (issue #70).
+ *
+ * Drives the already-authenticated page to the NotebookLM home, clicks the
+ * "+ Create new" button, and waits for the redirect to /notebook/<uuid>.
+ * Returns the new notebook URL + uuid so the caller can add sources / generate
+ * audio against a *clean* notebook — this is what lets a recurring task avoid
+ * stale-audio and source-accumulation from reusing one fixed notebook.
+ *
+ * Called with an already-initialised page (the session was bootstrapped on an
+ * existing notebook); we just navigate that page to the root and click.
+ */
+
+import type { Page } from "patchright";
+import { Selectors, joinAlt } from "./selectors.js";
+import { log } from "../utils/logger.js";
+
+export interface CreateNotebookResult {
+  success: boolean;
+  url?: string;
+  uuid?: string;
+  message?: string;
+}
+
+const HOMEPAGE = "https://notebooklm.google.com/";
+
+export async function createNotebook(page: Page): Promise<CreateNotebookResult> {
+  log.info("\u{1F4D3} [create_notebook] navigating to NotebookLM homepage");
+  const before = page.url();
+  await page.goto(HOMEPAGE, { waitUntil: "domcontentloaded", timeout: 30_000 });
+
+  // Wait for the home UI to render its create button.
+  try {
+    await page
+      .locator(joinAlt(Selectors.homepage.createButton))
+      .first()
+      .waitFor({ state: "visible", timeout: 20_000 });
+  } catch {
+    return {
+      success: false,
+      message:
+        `Could not find the "Create new" button on the NotebookLM homepage. ` +
+        `The homepage UI may have changed.`,
+    };
+  }
+
+  log.info("  \u{1F5B1}\uFE0F  clicking create button");
+  await page
+    .locator(joinAlt(Selectors.homepage.createButton))
+    .first()
+    .click({ timeout: 10_000 });
+
+  // Clicking create first shows a transient /notebook/creating placeholder, then
+  // redirects to the real /notebook/<uuid>. Require the full UUID shape so we
+  // don't capture the placeholder ("creating" would match a loose [a-f0-9-]+).
+  const UUID_RE =
+    /\/notebook\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+  try {
+    await page.waitForURL(UUID_RE, { timeout: 30_000 });
+  } catch {
+    return {
+      success: false,
+      message:
+        `Clicked "Create new" but no /notebook/<uuid> URL appeared within 30 s ` +
+        `(still at ${page.url()}, started from ${before}).`,
+    };
+  }
+
+  const url = page.url();
+  const uuid = url.match(
+    /notebook\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+  )?.[1];
+  if (!uuid) {
+    return { success: false, message: `Redirected but could not parse a notebook uuid from ${url}.` };
+  }
+  log.success(`  \u2705 new notebook created: ${uuid}`);
+  return { success: true, url, uuid };
+}

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -339,6 +339,30 @@ export const Selectors = {
     ],
   },
 
+  /**
+   * NotebookLM homepage (root URL) controls. The "+ Create new" button opens a
+   * fresh, empty notebook and redirects to /notebook/<uuid>. Class/icon anchors
+   * first, then visible-text (EN + major locales), same priority convention as
+   * sources.addButton.
+   */
+  homepage: {
+    createButton: [
+      "button.create-notebook-button",
+      'button[class*="create-notebook"]',
+      'button:has-text("Create new")',
+      'button:has-text("Create notebook")',
+      '[role="button"]:has-text("Create new")',
+      'button:has(mat-icon:text-is("add")):has-text("Create")',
+      'button:has-text("Neu erstellen")',
+      'button:has-text("Créer")',
+      'button:has-text("Crear")',
+      'button:has-text("Nuovo")',
+      'button:has-text("Criar")',
+      'button:has-text("Nieuw")',
+      'button:has-text("新規作成")',
+    ],
+  },
+
   notebooks: {
     projectCard: 'button[aria-labelledby*="project-"]',
     cardMenuButton: [

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -30,6 +30,10 @@ import {
   type AddSourceResult,
 } from "../notebooklm/sources.js";
 import {
+  createNotebook as createNotebookOnPage,
+  type CreateNotebookResult,
+} from "../notebooklm/create-notebook.js";
+import {
   generateAudioOverview as generateAudioOnPage,
   downloadAudioOverview as downloadAudioOnPage,
   getAudioStatusOnPage,
@@ -491,6 +495,19 @@ export class BrowserSession {
       await this.init();
     }
     return await addSourceToPage(this.page!, input);
+  }
+
+  /**
+   * Create a brand-new notebook via the homepage "+ Create new" button and
+   * return its fresh /notebook/<uuid> URL (issue #70). This session must have
+   * been bootstrapped on an existing notebook — createNotebook then drives the
+   * page to the homepage root itself.
+   */
+  async createNotebook(): Promise<CreateNotebookResult> {
+    if (!this.initialized || !this.page || this.isPageClosedSafe()) {
+      await this.init();
+    }
+    return await createNotebookOnPage(this.page!);
   }
 
   /**

--- a/src/tools/definitions/notebook-management.ts
+++ b/src/tools/definitions/notebook-management.ts
@@ -271,4 +271,66 @@ export const notebookManagementTools: Tool[] = [
       openWorldHint: false,
     },
   },
+  {
+    name: "create_notebook",
+    description:
+      "Create a brand-new, empty NotebookLM notebook by clicking \"+ Create new\" " +
+      "on the homepage, and return its fresh `/notebook/<uuid>` URL.\n\n" +
+      "Use this to get a clean notebook for a single batch of sources — the right " +
+      "pattern for recurring digests where each run needs its own notebook (reusing " +
+      "one notebook makes `generate_audio` return the previous, stale Audio Overview " +
+      "and blends every run's sources).\n\n" +
+      "Workflow: `create_notebook` → `add_source` (pass the returned `url` as " +
+      "`notebook_url`) → `generate_audio` → poll `get_audio_status`.\n\n" +
+      "Bootstraps a browser session from an existing notebook, so at least one " +
+      "notebook must already be registered (pass `notebook_id`/`notebook_url` to pin " +
+      "which one). Supply `name` (+ optional `description`/`topics`) to also register " +
+      "the new notebook in the local library as an archive entry.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description:
+            "Optional. If given, the new notebook is registered in the local library " +
+            "under this display name (e.g. 'FM Weekly Digest — 14 July 2026').",
+        },
+        description: {
+          type: "string",
+          description: "Optional 1–2 sentence summary for the library entry (defaults to `name`).",
+        },
+        topics: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional topics for the library entry.",
+        },
+        notebook_id: {
+          type: "string",
+          description:
+            "Existing library notebook id used only to bootstrap the browser session " +
+            "(not the notebook being created). Defaults to the active notebook.",
+        },
+        notebook_url: {
+          type: "string",
+          description:
+            "Existing NotebookLM URL used only to bootstrap the browser session. Overrides `notebook_id`.",
+        },
+        session_id: {
+          type: "string",
+          description: "Reuse an existing browser session by id (from `list_sessions`).",
+        },
+        show_browser: {
+          type: "boolean",
+          description: "Show the browser window for debugging. Default: false.",
+        },
+      },
+    },
+    annotations: {
+      title: "Create new notebook",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
 ];

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -14,6 +14,7 @@ import type {
   UpdateNotebookInput,
 } from "../library/types.js";
 import type { AddSourceResult } from "../notebooklm/sources.js";
+import type { CreateNotebookResult } from "../notebooklm/create-notebook.js";
 import type { AudioGenerationResult, DownloadAudioResult } from "../notebooklm/audio.js";
 import { CONFIG, applyBrowserOptions, type BrowserOptions } from "../config.js";
 import { log } from "../utils/logger.js";
@@ -632,6 +633,70 @@ export class ToolHandlers {
         success: false,
         error: errorMessage,
       };
+    }
+  }
+
+  /**
+   * Handle create_notebook tool (issue #70) — clicks "+ Create new" on the
+   * NotebookLM homepage and returns the fresh /notebook/<uuid> URL. Bootstraps
+   * an authenticated page off an existing notebook because session init requires
+   * a real notebook URL (it cannot init straight onto the homepage).
+   */
+  async handleCreateNotebook(args: {
+    name?: string;
+    description?: string;
+    topics?: string[];
+    session_id?: string;
+    notebook_id?: string;
+    notebook_url?: string;
+    show_browser?: boolean;
+  }): Promise<ToolResult<{ result: CreateNotebookResult; notebook?: NotebookEntry }>> {
+    log.info(`🔧 [TOOL] create_notebook called`);
+    const originalConfig = { ...CONFIG };
+    if (args.show_browser !== undefined) {
+      Object.assign(CONFIG, applyBrowserOptions(undefined, args.show_browser));
+    }
+    const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
+    try {
+      // Bootstrap an authenticated page off an existing notebook (session init
+      // cannot start on the bare homepage).
+      const bootstrapUrl = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
+      if (!bootstrapUrl) {
+        throw new Error(
+          "create_notebook needs an existing notebook to bootstrap a browser session. " +
+            "Register one with add_notebook (or select_notebook) first, or pass notebook_id/notebook_url."
+        );
+      }
+      const session = await this.sessionManager.getOrCreateSession(
+        args.session_id,
+        bootstrapUrl,
+        overrideHeadless
+      );
+      const result = await session.createNotebook();
+      if (!result.success) {
+        return { success: false, error: result.message ?? "create_notebook failed", data: { result } };
+      }
+      // Optionally register the fresh notebook in the local library (archive).
+      let notebook: NotebookEntry | undefined;
+      if (args.name && result.url) {
+        try {
+          notebook = this.library.addNotebook({
+            url: result.url,
+            name: args.name,
+            description: args.description ?? args.name,
+            topics: args.topics ?? [],
+          });
+        } catch (e) {
+          log.warning(`  ⚠️  library.addNotebook skipped: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+      return { success: true, data: { result, notebook } };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error(`❌ [TOOL] create_notebook failed: ${msg}`);
+      return { success: false, error: msg };
+    } finally {
+      Object.assign(CONFIG, originalConfig);
     }
   }
 


### PR DESCRIPTION
## What

Adds a `create_notebook` MCP tool that clicks the NotebookLM homepage **"+ Create new"** button and returns the fresh `/notebook/<uuid>` URL.

Closes the gap where the package could only *register* an existing notebook (`add_notebook`) but never *create* one.

## Why

Recurring / batch workflows currently have to reuse one fixed notebook, which hits two structural NotebookLM problems:

1. **Stale audio** — `generate_audio` against a notebook that already has an Overview returns the old one (`status: "ready", alreadyExisted: true`) instead of rendering a fresh one. No delete-audio path exists, so an automated weekly job can never produce a current podcast.
2. **Source accumulation / blending** — sources pile up toward the 50-source cap and a new Overview blends every run's sources.

A fresh notebook per run fixes both. Full context in #70.

## How

`create_notebook` bootstraps an authenticated page off an existing notebook (via `resolveNotebookUrl` / the active notebook), then navigates *that* page to the homepage root and clicks create. This sidesteps the fact that `getOrCreateSession` / `BrowserSession.init()` can't start a session on the bare homepage (the same "needs an existing notebook" constraint described in #46).

Workflow: `create_notebook` → `add_source` (pass returned `url` as `notebook_url`) → `generate_audio` → poll `get_audio_status`.

## Gotcha handled

After clicking create, NotebookLM briefly shows a transient `/notebook/creating` placeholder before redirecting to the real UUID. A loose `/notebook\/([a-f0-9-]+)/` match captures `"creating"` (→ uuid `"c"`), so the wait/extract requires the full UUID shape:

```
/\/notebook\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
```

## Changes

6 files, +260 lines, mirroring the `add_source` structure:

- `notebooklm/create-notebook.ts` *(new)* — page action
- `notebooklm/selectors.ts` — `homepage.createButton` fallback list
- `session/browser-session.ts` — `createNotebook()` wrapper
- `tools/handlers.ts` — `handleCreateNotebook()`
- `tools/definitions/notebook-management.ts` — tool definition
- `index.ts` — dispatch case

Exposed automatically under the default `full` profile.

## Testing

- `npm run build` (tsc) passes clean.
- Verified end-to-end against the 2026-07 NotebookLM UI: `create_notebook` → real UUID, `add_source` count 0→1, `generate_audio` returned `started` (not `alreadyExisted`), `get_audio_status` reached `ready`.

Notes: browser-driven, so it depends on the current homepage markup — the selector list is multi-anchor + locale-aware to soften future UI drift, and it fails with a clear message + no partial state if the button can't be found.
