### PR TITLE
fix(selectors): stop chat queryInput fallbacks matching the source-discovery box

### DIFF
--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -35,18 +35,26 @@ export const Selectors = {
     /**
      * Chat textarea. The class is shared across locales; aria-labels are a
      * fallback for older builds where the class was different.
+     *
+     * The source-discovery box (`textarea.query-box-textarea`, "Discover
+     * sources based on the inputted query" / "Search the web for new
+     * sources") is a distractor that matches the same aria-label substrings
+     * — every locale describes it in terms of a *query* too. Typing into it
+     * would silently send the user's question to web-source discovery instead
+     * of the chat, so each fallback MUST carry
+     * `:not(.query-box-textarea)`. Same rule as `submitButton` below.
      */
     queryInput: [
       "textarea.query-box-input",
-      'textarea[aria-label*="query" i]',
-      'textarea[aria-label*="anfrag" i]',
-      'textarea[aria-label*="requete" i]',
-      'textarea[aria-label*="zone de requete" i]',
-      'textarea[aria-label*="consulta" i]',
-      'textarea[aria-label*="domanda" i]',
-      'textarea[aria-label*="vraag" i]',
-      'textarea[aria-label*="質問" i]',
-      'textarea[aria-label*="pergunta" i]',
+      'textarea[aria-label*="query" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="anfrag" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="requete" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="zone de requete" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="consulta" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="domanda" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="vraag" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="質問" i]:not(.query-box-textarea)',
+      'textarea[aria-label*="pergunta" i]:not(.query-box-textarea)',
     ],
     /**
      * The chat submit button has the *language-bound* aria-label

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -19,6 +19,7 @@ import type { AuthManager } from "../auth/auth-manager.js";
 import { humanType, randomDelay } from "../utils/stealth-utils.js";
 import { snapshotAllResponses } from "../utils/page-utils.js";
 import { waitForStableAnswer, snapshotPriorAnswers } from "../notebooklm/chat.js";
+import { Selectors } from "../notebooklm/selectors.js";
 import {
   extractCitations as extractCitationsFromPage,
   type SourceFormat,
@@ -554,18 +555,7 @@ export class BrowserSession {
       return null;
     }
 
-    const selectors = [
-      // Stable class — language-agnostic.
-      "textarea.query-box-input",
-      // Locale-bound aria-label fallbacks for older builds.
-      'textarea[aria-label="Feld für Anfragen"]',
-      'textarea[aria-label*="anfrag" i]',
-      'textarea[aria-label*="query" i]',
-      'textarea[aria-label*="zone de requete" i]',
-      'textarea[aria-label*="requete" i]',
-      'textarea[aria-label*="consulta" i]',
-      'textarea[aria-label*="domanda" i]',
-    ];
+    const selectors = Selectors.chat.queryInput;
 
     const tryFind = async (): Promise<string | null> => {
       for (const selector of selectors) {


### PR DESCRIPTION
## What

The `aria-label` fallbacks in `chat.queryInput` ([`src/notebooklm/selectors.ts`](https://github.com/PleasePrompto/notebooklm-mcp/blob/main/src/notebooklm/selectors.ts)) match **two** textareas on the current live NotebookLM page:

| Element | Class | aria-label |
|---|---|---|
| Real chat box | `query-box-input` | "Query box" |
| Source-discovery box | `query-box-textarea` | "Discover sources based on the inputted query" |

This PR adds `:not(.query-box-textarea)` to every fallback so only the chat box can match.

## Why

**This is a latent bug, not a live one.** The class-anchored primary selector `textarea.query-box-input` matches first today, so the fallbacks never get a chance to misfire. The risk is what happens if Google renames that class: the fallbacks would silently type the user's question into the *source-discovery* box ("Search the web for new sources") instead of the chat. The user would get no answer and an unexpected web-source search.

The file already documents exactly this hazard for `submitButton`:

> The sources web-search overlay uses `.actions-enter-button` with the SAME aria-label, so we MUST anchor on `.submit-button` to avoid distractor matches.

`sources.ts:259` likewise already guards with `:not(.query-box-input):not(.query-box-textarea)`. This change applies the established idiom to `queryInput`.

## Notes for reviewers

**The guard is on all locales, not just English.** The discovery box's aria-label is localized too, and every locale describes it in terms of a *query* (query / Anfrage / consulta / …) — the same vocabulary the chat box uses. So the German and Spanish fallbacks were as exposed as the English one.

**Anchoring on the literal "Query box" aria-label was considered and rejected.** It would defeat the intentional multilingual substring matching the registry is built around. `:not()` keeps every locale working.

**`findChatInput` de-duplicated.** `browser-session.ts` carried a hand-rolled copy of this selector list with the identical bug, which had drifted to five fewer locales. It now reads `Selectors.chat.queryInput`. Its exact-match `textarea[aria-label="Feld für Anfragen"]` is subsumed by the registry's `*="anfrag" i`, so no coverage is lost.

**`waitForNotebookLMReady` deliberately unchanged.** It anchors on the class and falls back to an *exact* aria-label match — neither can hit the distractor — and it never types. Its Python-parity comments are left intact.

## Verification

- `npm run build` — clean.
- `npx eslint src` — one warning, pre-existing and in `transport/http.ts`, untouched by this change.
- **Behaviour** — since the bug is latent, no existing test exercises it, and I have no live NotebookLM login to drive. I verified against a DOM fixture reproducing both textareas in a real browser engine (these are plain CSS constructs Playwright passes through to the browser):
  - Today's DOM: old fallback matches **both** textareas (confirming the distractor is real, not theoretical); new fallback matches only `"Query box"`.
  - With `.query-box-input` renamed to simulate the future breakage: old fallback still matches both; new joined selector resolves to the chat box alone, and no fallback touches the distractor.

Happy to adjust or drop this if you'd rather not carry the extra `:not()` noise for a bug that can't currently fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)