### PR TITLE
fix(chat): skip Gemini 2.5 extended-thinking summary in answer extrac…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc --watch",
     "dev": "tsx watch src/index.ts",
     "prepare": "npm run build",
-    "test": "tsx src/index.ts",
+    "test": "node --import tsx --test test/*.test.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write src",

--- a/src/notebooklm/chat.ts
+++ b/src/notebooklm/chat.ts
@@ -172,9 +172,54 @@ const RATE_LIMIT_MESSAGES = [
   "1日あたりの上限に達しました",
 ];
 
-function isPlaceholder(text: string): boolean {
+/**
+ * Gemini 2.5 renders an "extended thinking" summary into the SAME
+ * `.message-text-content` element before it is replaced by the final answer
+ * (issue #74). NotebookLM ships no dedicated CSS class for this block — verified
+ * against the live 2026-07 DOM, where the settled answer turn holds exactly one
+ * `.message-text-content` containing only the final response — so it must be
+ * detected by shape. The summary is emitted in English even when the answer is
+ * not, and follows a stable pattern:
+ *
+ *   <Gerund Title-Case header, no terminal punctuation>\n
+ *   <first-person, present-continuous planning prose>
+ *
+ * Verbatim examples:
+ *   "Clarifying Initial Requests\nI'm currently focused on structuring…"
+ *   "Refining the Focus\nI'm now zeroing in on the common thread…"
+ *   "Defining the Summary Scope\nMy next task is to…"
+ *
+ * Requiring BOTH the header shape AND first-person planning language keeps this
+ * from misfiring on grounded answers, which are third-person and source-cited.
+ */
+const THINKING_TITLE = /^[A-Z][a-z]+ing\b[^\n.!?。？！]{0,60}$/;
+const THINKING_FIRST_PERSON =
+  /\b(?:I['’]?m|I['’]?ll|I['’]?ve|I will|I am|I need to|I want to|My (?:immediate |current |next |primary |main )?(?:task|aim|goal|plan|approach|focus|objective|step)|Let me)\b/;
+const THINKING_OPENER =
+  /^(?:I['’]?m|I['’]?ll|I will|I am|My (?:next|immediate|current|primary|main)\s+(?:task|aim|goal|plan|step|focus))\b/i;
+
+export function isThinkingStep(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  const firstLine = trimmed.split("\n", 1)[0].trim();
+
+  // Shape 1: a short gerund header followed by first-person planning prose.
+  const gerundHeader = THINKING_TITLE.test(firstLine) && firstLine.split(/\s+/).length <= 7;
+  if (gerundHeader && THINKING_FIRST_PERSON.test(trimmed)) return true;
+
+  // Shape 2: a title-less summary that opens directly with planning language.
+  if (THINKING_OPENER.test(firstLine)) return true;
+
+  return false;
+}
+
+export function isPlaceholder(text: string): boolean {
   const lower = text.toLowerCase();
   if (PLACEHOLDER_SNIPPETS.some((s) => lower.includes(s))) return true;
+  // Gemini 2.5's extended-thinking summary is "stable" while the model is still
+  // working; treat it as a placeholder so the poller keeps waiting for the
+  // final answer that replaces it (issue #74).
+  if (isThinkingStep(text)) return true;
   // Short text ending with "..." is almost certainly a loading indicator;
   // real responses run well past 50 chars.
   if (text.length < 50 && text.trim().endsWith("...")) return true;

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for issue #74 — `waitForStableAnswer()` latching onto
+ * Gemini 2.5's extended-thinking summary instead of the final answer.
+ *
+ * The positive fixtures are verbatim thinking summaries captured from live
+ * `ask_question` calls; the negatives are real grounded answers (including a
+ * deliberately adversarial one whose first line is a gerund heading, and one
+ * that contains "will" in third person).
+ *
+ * Run: `npm test`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isThinkingStep, isPlaceholder } from "../src/notebooklm/chat.js";
+
+const THINKING_SUMMARIES = [
+  "Clarifying Initial Requests\nI'm currently focused on structuring a concise explanation of the \"automated feedback loop with AI agents\" concept, geared towards a novice audience. I'm prioritizing clarity and brevity. My immediate task is to outline the three key elements users are looking for: the process itself, the benefits derived, and the potential challenges encountered. I'll provide an initial draft after completing these steps.",
+  "Refining the Focus\nI'm now zeroing in on the common thread: the transition from manual prompting to constructing automated feedback loops with AI agents [1, 2]. My current aim is to express this in Japanese, keeping it concise and source-supported. I will adhere to the constraints precisely.",
+  "Refining the Approach\nI'm now focused on understanding the user's feedback. They've pointed out the previous response wasn't a finished thought process, but rather an incomplete one. I'm actively reviewing instructions to solidify this understanding.",
+  "Defining the Summary Scope\nMy next task is to distil the sources into a two-sentence summary. I'm now zeroing in on the key themes.",
+];
+
+const REAL_ANSWERS = [
+  // The actual Japanese answer that should have been returned.
+  "「ループエンジニアリングにおけるループの基本動作については、システムを設計する上での「5つの基本動作（Five Moves）」と、AIエージェントが実際に処理を進める「5つのサイクル」の2つの観点から説明できます。",
+  // Grounded, third-person English answer.
+  "The automated feedback loop consists of three stages: the agent proposes an action, the environment returns an observation, and the result is scored against the goal [1]. Unlike manual prompting, no human intervention is required between iterations [2].",
+  // Adversarial: first line IS a gerund heading, but the body is third-person.
+  "Understanding the Five Moves\nThe framework defines five core moves that a system designer applies when composing an automated loop. Each move maps to a distinct responsibility.",
+  // Contains "will" in third person — must not be mistaken for planning prose.
+  "The document explains that the system will retry failed steps automatically. It will also log each attempt for later review.",
+  // Short factual answer.
+  "Yes. The sources confirm that automated loops reduce manual prompting overhead [1].",
+];
+
+test("isThinkingStep flags Gemini extended-thinking summaries (#74)", () => {
+  for (const sample of THINKING_SUMMARIES) {
+    assert.ok(isThinkingStep(sample), `should flag as thinking: ${sample.slice(0, 48)}…`);
+  }
+});
+
+test("isThinkingStep does not misfire on grounded answers", () => {
+  for (const answer of REAL_ANSWERS) {
+    assert.ok(!isThinkingStep(answer), `should NOT flag as thinking: ${answer.slice(0, 48)}…`);
+  }
+});
+
+test("isPlaceholder treats thinking summaries as non-final answers (#74)", () => {
+  for (const sample of THINKING_SUMMARIES) {
+    assert.ok(isPlaceholder(sample), "thinking summary must read as placeholder");
+  }
+});
+
+test("isPlaceholder still accepts real answers as final", () => {
+  for (const answer of REAL_ANSWERS) {
+    assert.ok(!isPlaceholder(answer), "real answer must not read as placeholder");
+  }
+});


### PR DESCRIPTION
…tion

waitForStableAnswer() could return Gemini's extended-thinking summary instead of the final answer (#74). The summary streams into the same `.message-text-content` element and stays stable while the model finishes thinking, so the stability poller accepted it before the real answer replaced it. isPlaceholder() did not recognise the new "thinking step" format.

Verified against the live 2026-07 NotebookLM DOM: the settled answer turn holds exactly one `.message-text-content` containing only the final answer, and there is no dedicated CSS class for the thinking block — so it must be detected by shape.

Add isThinkingStep() (a gerund-title + first-person planning shape, or a first-person planning opener) and treat it as a placeholder so the poller keeps waiting for the real answer. Add test/chat.test.ts with verbatim captured thinking summaries plus real grounded answers (incl. an adversarial gerund-headed answer and a third-person "will" answer), and wire `npm test` to the node test runner (was a placeholder).

Refs #74