### PR TITLE
Improve NotebookLM auth, HTTP safety, and session reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ chrome_profile/
 .notebooklm-mcp/
 .claude/
 CLAUDE.md
+.rtfm/
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ All configuration is via environment variables and tool parameters. There is no 
 | `HEADLESS` | `true` | Run Chrome headless. Override per-call with `show_browser` / `browser_options.show`. |
 | `ANSWER_TIMEOUT_MS` | `600000` | Hard ceiling on the wait for a NotebookLM answer. |
 | `BROWSER_TIMEOUT` | `30000` | Per-action browser timeout. |
+| `NOTEBOOKLM_DATA_DIR` | platform data directory | Explicit root for auth state, Chrome profiles, and `library.json`. |
 | `MAX_SESSIONS` | `10` | Concurrent browser sessions. |
 | `SESSION_TIMEOUT` | `900` | Idle seconds before a session is GC-ed. |
 | `STEALTH_ENABLED` | `true` | Master switch for human-typing/mouse/delay stealth. |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MCP server for Google NotebookLM. It drives a real Chrome via Patchright (stealt
 
 ## Requirements & Platform Support
 
-- **Node.js** ≥ 18.
+- **Node.js** ≥ 22.13.
 - **Chrome** (stable channel) preferred. The bundled Patchright Chromium is used as a fallback when Chrome refuses to launch — set `BROWSER_CHANNEL=chromium` to force it.
 - **Linux / macOS / Windows.**
 - **WSL2 + WSLg** (Windows 11+) is fully supported. WSL1 cannot launch a Chromium and is not supported — upgrade to WSL2.
@@ -129,7 +129,7 @@ Profile location (env-paths):
 
 Auth tools:
 
-- `setup_auth` — first-time login. Pass `show_browser=true` (default for setup) to see the window. Returns immediately after launching the window; you have up to 10 min to complete the login.
+- `setup_auth` — first-time login. Pass `show_browser=true` (default for setup) to see the window. The call waits for login completion for up to 10 minutes and reports progress.
 - `re_auth` — wipe stored auth and start over. Use when switching Google accounts or when authentication is broken.
 - `cleanup_data` — full cleanup with categorised preview. Pass `preserve_library=true` to keep `library.json` while wiping browser state.
 
@@ -151,8 +151,8 @@ npx notebooklm-mcp@latest
 
 ```bash
 npx notebooklm-mcp@latest --transport http --port 3000
-# bind to all interfaces:
-npx notebooklm-mcp@latest --transport http --port 3000 --host 0.0.0.0
+# Binding outside localhost requires a bearer token:
+NOTEBOOKLM_HTTP_AUTH_TOKEN="replace-with-a-long-random-token" npx notebooklm-mcp@latest --transport http --port 3000 --host 0.0.0.0
 ```
 
 Equivalent env vars: `NOTEBOOKLM_TRANSPORT=http`, `NOTEBOOKLM_PORT=3000`, `NOTEBOOKLM_HOST=0.0.0.0`.
@@ -168,7 +168,11 @@ Routes:
 
 The server uses the MCP SDK's `StreamableHTTPServerTransport`, which manages session lifecycle through the `Mcp-Session-Id` response/request header. A new session is created when the first `POST /mcp` body is an `initialize` request; from then on the client must echo the returned `Mcp-Session-Id` on every request.
 
-Default host is `127.0.0.1`. Bind to `0.0.0.0` only when the server is reachable on a trusted network.
+Default host is `127.0.0.1`. Binding to a non-loopback address is rejected
+unless `NOTEBOOKLM_HTTP_AUTH_TOKEN` is set. Clients then send
+`Authorization: Bearer <token>`. Use `NOTEBOOKLM_ALLOWED_HOSTS` and
+`NOTEBOOKLM_ALLOWED_ORIGINS` to allow the public names that proxy/browser
+clients use; both variables accept comma-separated values.
 
 ---
 
@@ -353,6 +357,10 @@ All configuration is via environment variables and tool parameters. There is no 
 | `NOTEBOOKLM_TRANSPORT` | `stdio` | `stdio` or `http`. |
 | `NOTEBOOKLM_PORT` | `3000` | HTTP port. |
 | `NOTEBOOKLM_HOST` | `127.0.0.1` | HTTP bind address. |
+| `NOTEBOOKLM_HTTP_AUTH_TOKEN` | _(unset)_ | Bearer token for HTTP. Required outside localhost. |
+| `NOTEBOOKLM_ALLOWED_HOSTS` | loopback hosts | Comma-separated HTTP Host allowlist. |
+| `NOTEBOOKLM_ALLOWED_ORIGINS` | loopback origins | Comma-separated browser Origin allowlist. |
+| `NOTEBOOKLM_HTTP_MAX_BODY_BYTES` | `1048576` | Maximum HTTP request body size. |
 | `NOTEBOOKLM_ACCOUNT` | _(unset)_ | Multi-account profile slug. |
 | `NOTEBOOKLM_PROFILE` | `full` | Tool profile (`minimal` / `standard` / `full`). |
 | `NOTEBOOKLM_DISABLED_TOOLS` | _(unset)_ | Comma-separated tool names to suppress. |
@@ -366,11 +374,21 @@ All configuration is via environment variables and tool parameters. There is no 
 ## Development
 
 ```bash
-npm run build      # tsc + chmod +x dist/index.js
+npm run build      # compile TypeScript
 npm run dev        # tsx watch src/index.ts
 npm run lint       # eslint src
-npm run format     # prettier --write src
-npm run check      # format:check + lint + build
+npm run format     # format source, tests, and local scripts
+npm test           # unit and transport tests
+npm run check      # format:check + lint + build + tests
+```
+
+For a local HTTP smoke test, start the server and use the bundled client:
+
+```bash
+node ./dist/index.js --transport http --host 127.0.0.1 --port 3000
+npm run mcp:smoke
+npm run mcp:auth
+npm run mcp:ask -- "Summarize the active notebook"
 ```
 
 The build is type-safe with no `any` casts; DOM types are enabled for in-page evaluations.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,10 @@ The server uses `env-paths` with no suffix. Default locations:
 | macOS | `~/Library/Application Support/notebooklm-mcp/` | `~/Library/Preferences/notebooklm-mcp/` |
 | Windows | `%APPDATA%\notebooklm-mcp\` | `%APPDATA%\notebooklm-mcp\Config\` |
 
+Set `NOTEBOOKLM_DATA_DIR` to use an explicit data root instead of the
+platform default. `browser_state/`, `chrome_profile/`, profile instances, and
+`library.json` are all resolved below that directory.
+
 Subdirectories under `dataDir`:
 
 - `chrome_profile/` — persistent Chrome profile (cookies, fingerprint).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ Subdirectories under `dataDir`:
 |---|---|---|---|
 | `HEADLESS` | bool | `true` | Run Chrome headless. Per-call override via `show_browser` or `browser_options.show`. |
 | `BROWSER_TIMEOUT` | int (ms) | `30000` | Per-action browser timeout. |
-| `ANSWER_TIMEOUT_MS` | int (ms) | `600000` | Hard ceiling on the wait for a NotebookLM answer. Per-call override via `browser_options.timeout_ms`. |
+| `ANSWER_TIMEOUT_MS` | int (ms) | `600000` | Hard ceiling on the wait for a NotebookLM answer. Per-call override via `browser_options.answer_timeout_ms`. |
 | `BROWSER_CHANNEL` | enum | `chrome` | `chrome` or `chromium`. `chromium` forces the bundled Patchright build. |
 | `NOTEBOOKLM_BROWSER_CHANNEL` | enum | _(falls back to `BROWSER_CHANNEL`)_ | Same as above. Either name works. |
 
@@ -94,6 +94,14 @@ Slug rules: `[a-z0-9][a-z0-9-_]{0,30}`, case-insensitive (lowercased internally)
 | `NOTEBOOKLM_TRANSPORT` | enum | `stdio` | `stdio` or `http`. CLI flag `--transport` overrides. |
 | `NOTEBOOKLM_PORT` | int | `3000` | HTTP port. CLI flag `--port` overrides. |
 | `NOTEBOOKLM_HOST` | string | `127.0.0.1` | HTTP bind address. CLI flag `--host` overrides. |
+| `NOTEBOOKLM_HTTP_AUTH_TOKEN` | string | _(unset)_ | Bearer token. Required when binding outside localhost. |
+| `NOTEBOOKLM_ALLOWED_HOSTS` | CSV | loopback hosts | Allowed HTTP `Host` values. Add the public proxy hostname here. |
+| `NOTEBOOKLM_ALLOWED_ORIGINS` | CSV | loopback origins | Allowed browser `Origin` values. |
+| `NOTEBOOKLM_HTTP_MAX_BODY_BYTES` | int | `1048576` | Maximum JSON request size. |
+
+Requests with an `Origin` header are rejected unless the origin is loopback or
+listed explicitly. When an auth token is configured, clients must send
+`Authorization: Bearer <token>`.
 
 ## Profiles & tool filtering
 
@@ -147,6 +155,7 @@ These set the description used for the legacy fallback when no notebook is activ
   "show": true,
   "headless": false,
   "timeout_ms": 60000,
+  "answer_timeout_ms": 600000,
   "stealth": {
     "enabled": true,
     "random_delays": true,
@@ -160,5 +169,9 @@ These set the description used for the legacy fallback when no notebook is activ
   "viewport": { "width": 1024, "height": 768 }
 }
 ```
+
+`timeout_ms` controls individual browser actions. `answer_timeout_ms` controls
+the complete wait for a generated answer. Overrides are request-scoped and do
+not mutate configuration used by concurrent HTTP calls.
 
 `show_browser` is a shorthand for `browser_options.show` and exists only on `ask_question`, `setup_auth`, `re_auth`. When both are present, `browser_options` wins.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -45,7 +45,7 @@ Ask a question against a notebook. Reuses an existing browser session when `sess
   "question": "How does the OAuth refresh token rotation work?",
   "answer": "[AI-GENERATED ...] The refresh token is rotated each ...\n\nSources:\n[1] auth-spec.pdf — ...",
   "session_id": "ses_…",
-  "notebook_url": "https://notebooklm.google.com/notebook/…",
+  "notebook_url": "https://notebook.google.com/notebook/…",
   "session_info": {
     "age_seconds": 12,
     "message_count": 3,
@@ -232,7 +232,7 @@ No parameters. Returns the full library.
     {
       "id": "nb_abcd",
       "name": "n8n Documentation",
-      "url": "https://notebooklm.google.com/notebook/…",
+      "url": "https://notebook.google.com/notebook/…",
       "description": "n8n core + builtin nodes",
       "topics": ["workflow automation", "n8n"],
       "use_cases": ["building n8n workflows"],

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -39,13 +39,13 @@ Expect `"authenticated": true`.
 
 ### 3. Add a notebook to the local library
 
-Get a NotebookLM share-URL: open the notebook in `notebooklm.google.com`, click _Share → Anyone with the link → Copy link_. Then:
+Get a NotebookLM share-URL: open the notebook in `notebook.google.com`, click _Share → Anyone with the link → Copy link_. Legacy `notebooklm.google.com` links are also accepted. Then:
 
 ```json
 {
   "name": "add_notebook",
   "arguments": {
-    "url": "https://notebooklm.google.com/notebook/abcd-efgh",
+    "url": "https://notebook.google.com/notebook/abcd-efgh",
     "name": "n8n Documentation",
     "description": "n8n core docs + builtin nodes",
     "topics": ["workflow automation", "n8n", "node configuration"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "notebooklm-mcp",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notebooklm-mcp",
-      "version": "1.2.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
-        "dotenv": "^16.4.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "env-paths": "^3.0.0",
         "globby": "^14.1.0",
         "patchright": "^1.48.2",
@@ -21,7 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^20.11.0",
+        "@types/node": "^22.13.0",
         "eslint": "^10.2.1",
         "prettier": "^3.8.3",
         "tsx": "^4.7.0",
@@ -29,7 +28,7 @@
         "typescript-eslint": "^8.59.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -602,6 +601,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -669,27 +680,66 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
-      "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -760,9 +810,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.21.tgz",
-      "integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1029,6 +1079,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1041,6 +1092,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1052,36 +1142,53 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1135,15 +1242,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -1233,18 +1341,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1305,9 +1401,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1583,18 +1679,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -1625,10 +1722,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1665,6 +1766,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -1673,6 +1775,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -1709,9 +1827,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1722,7 +1840,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -1911,9 +2033,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1922,41 +2044,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -1983,6 +2113,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2035,6 +2174,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2046,7 +2194,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2105,12 +2260,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -2157,15 +2316,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -2357,9 +2520,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2379,9 +2542,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2442,18 +2605,20 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2483,43 +2648,40 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
       }
     },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2581,26 +2743,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2621,31 +2763,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -2655,6 +2801,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -2685,14 +2835,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2704,13 +2854,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2908,17 +3058,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2991,6 +3158,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -3059,12 +3227,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mcp:smoke": "node scripts/mcp-client.mjs health",
     "mcp:auth": "node scripts/mcp-client.mjs auth",
     "mcp:ask": "node scripts/mcp-client.mjs ask",
+    "mcp:inspect": "node scripts/inspect-live-chat.mjs",
     "check": "npm run format:check && npm run lint && npm run build && npm test"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -8,16 +8,18 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "chmod +x dist/index.js",
     "watch": "tsc --watch",
     "dev": "tsx watch src/index.ts",
     "prepare": "npm run build",
-    "test": "tsx src/index.ts",
+    "test": "tsx --test tests/**/*.test.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "format": "prettier --write src",
-    "format:check": "prettier --check src",
-    "check": "npm run format:check && npm run lint && npm run build"
+    "format": "prettier --write src tests scripts",
+    "format:check": "prettier --check src tests scripts",
+    "mcp:smoke": "node scripts/mcp-client.mjs health",
+    "mcp:auth": "node scripts/mcp-client.mjs auth",
+    "mcp:ask": "node scripts/mcp-client.mjs ask",
+    "check": "npm run format:check && npm run lint && npm run build && npm test"
   },
   "keywords": [
     "mcp",
@@ -39,13 +41,11 @@
   "files": [
     "dist",
     "README.md",
-    "NOTEBOOKLM_USAGE.md",
     "LICENSE",
     "docs"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
-    "dotenv": "^16.4.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "env-paths": "^3.0.0",
     "globby": "^14.1.0",
     "patchright": "^1.48.2",
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^20.11.0",
+    "@types/node": "^22.13.0",
     "eslint": "^10.2.1",
     "prettier": "^3.8.3",
     "tsx": "^4.7.0",
@@ -61,6 +61,6 @@
     "typescript-eslint": "^8.59.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.13.0"
   }
 }

--- a/scripts/inspect-live-chat.mjs
+++ b/scripts/inspect-live-chat.mjs
@@ -102,7 +102,9 @@ async function inspectChat() {
     const chatMessages = Array.from(document.querySelectorAll("chat-message"));
     const textareas = Array.from(document.querySelectorAll("textarea"));
     const submitButtons = Array.from(
-      document.querySelectorAll("button.submit-button, button[class*='submit'], button[class*='stop']")
+      document.querySelectorAll(
+        "button.submit-button, button[class*='submit'], button[class*='stop']"
+      )
     ).map((element) => ({
       ...describe(element),
       disabled: element.disabled,
@@ -228,9 +230,7 @@ try {
   });
 
   const before = await settleChatHistory();
-  const latestAnswerLocator = page.locator(
-    ".to-user-container:last-of-type .message-text-content"
-  );
+  const latestAnswerLocator = page.locator(".to-user-container:last-of-type .message-text-content");
   console.log(
     JSON.stringify(
       {

--- a/scripts/inspect-live-chat.mjs
+++ b/scripts/inspect-live-chat.mjs
@@ -1,0 +1,357 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { chromium } from "patchright";
+import { CONFIG } from "../dist/config.js";
+
+const claudeDesktopDataDir = path.join(
+  os.homedir(),
+  "AppData",
+  "Local",
+  "Packages",
+  "Claude_pzs8sxrjxfjjc",
+  "LocalCache",
+  "Local",
+  "notebooklm-mcp",
+  "Data"
+);
+const candidateDataDirs = [
+  process.env.NOTEBOOKLM_DATA_DIR,
+  CONFIG.dataDir,
+  claudeDesktopDataDir,
+].filter(Boolean);
+let dataDir;
+
+for (const candidate of candidateDataDirs) {
+  try {
+    await fs.access(path.join(candidate, "library.json"));
+    dataDir = candidate;
+    break;
+  } catch {
+    // Try the next known host-specific data location.
+  }
+}
+
+if (!dataDir) {
+  throw new Error(`Could not locate library.json in: ${candidateDataDirs.join(", ")}`);
+}
+
+const libraryPath = path.join(dataDir, "library.json");
+const statePath = path.join(dataDir, "browser_state", "state.json");
+const library = JSON.parse(await fs.readFile(libraryPath, "utf8"));
+const activeNotebook = library.notebooks.find(
+  (notebook) => notebook.id === library.active_notebook_id
+);
+
+if (!activeNotebook) {
+  throw new Error(`No active notebook found in ${libraryPath}`);
+}
+
+let browser;
+try {
+  browser = await chromium.launch({ channel: "chrome", headless: true });
+} catch {
+  browser = await chromium.launch({ headless: true });
+}
+
+const context = await browser.newContext({
+  storageState: statePath,
+  viewport: CONFIG.viewport,
+});
+const page = await context.newPage();
+
+function compactText(value, maxLength = 240) {
+  return value.replace(/\s+/g, " ").trim().slice(0, maxLength);
+}
+
+async function inspectChat() {
+  return await page.evaluate(() => {
+    const describe = (element) => ({
+      tag: element.tagName.toLowerCase(),
+      className: element.className || "",
+      ariaLabel: element.getAttribute("aria-label"),
+      role: element.getAttribute("role"),
+      title: element.getAttribute("title"),
+    });
+
+    const answerContainers = Array.from(document.querySelectorAll(".to-user-container"));
+    const answerTexts = Array.from(
+      document.querySelectorAll(".to-user-container .message-text-content")
+    );
+    const assistantMessages = answerContainers.map((element) => {
+      const textElement = element.querySelector(".message-text-content");
+      return {
+        text: (textElement?.innerText || textElement?.textContent || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 240),
+        hasActions: Boolean(element.querySelector(".message-actions")),
+        actionText: (element.querySelector(".message-actions")?.textContent || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 120),
+        citationCount: element.querySelectorAll(".citation-marker").length,
+        directChildren: Array.from(
+          element.querySelector(".to-user-message-card-content")?.children || []
+        ).map((child) => ({
+          ...describe(child),
+          text: (child.textContent || "").replace(/\s+/g, " ").trim().slice(0, 120),
+        })),
+      };
+    });
+    const chatMessages = Array.from(document.querySelectorAll("chat-message"));
+    const textareas = Array.from(document.querySelectorAll("textarea"));
+    const submitButtons = Array.from(
+      document.querySelectorAll("button.submit-button, button[class*='submit'], button[class*='stop']")
+    ).map((element) => ({
+      ...describe(element),
+      disabled: element.disabled,
+      text: (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 120),
+    }));
+    const generationSignals = Array.from(
+      document.querySelectorAll(
+        "[aria-busy='true'], mat-spinner, mat-progress-spinner, [class*='thinking'], [class*='loading'], [class*='generating']"
+      )
+    )
+      .filter((element) => {
+        const style = getComputedStyle(element);
+        return style.display !== "none" && style.visibility !== "hidden";
+      })
+      .map((element) => ({
+        ...describe(element),
+        text: (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 120),
+      }));
+    const latestAnswerElement = answerContainers.at(-1);
+    const latestAnswerStructure = latestAnswerElement
+      ? Array.from(latestAnswerElement.querySelectorAll("*"))
+          .filter((element) =>
+            /message|answer|reason|think|loading|response|content|citation/i.test(
+              `${element.tagName} ${element.className || ""}`
+            )
+          )
+          .slice(-30)
+          .map((element) => ({
+            ...describe(element),
+            text: (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 100),
+          }))
+      : [];
+    const controls = Array.from(
+      document.querySelectorAll("button, [role='button'], [aria-label], [title]")
+    )
+      .map((element) => ({
+        ...describe(element),
+        text: (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 120),
+      }))
+      .filter((item) =>
+        /chat|conversation|new|reset|clear|history|mensaje|conversaci|nuevo|reinici/i.test(
+          `${item.ariaLabel || ""} ${item.title || ""} ${item.text}`
+        )
+      );
+
+    return {
+      url: location.href,
+      answerContainerCount: answerContainers.length,
+      answerTextCount: answerTexts.length,
+      latestAnswer: (answerTexts.at(-1)?.textContent || "").slice(0, 500),
+      assistantMessages: assistantMessages.slice(-6),
+      chatMessages: chatMessages.slice(-6).map((element) => ({
+        ...describe(element),
+        children: Array.from(element.children).map(describe),
+        text: (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 160),
+      })),
+      answerContainer: answerContainers.at(-1)
+        ? {
+            ...describe(answerContainers.at(-1)),
+            parent: answerContainers.at(-1).parentElement
+              ? describe(answerContainers.at(-1).parentElement)
+              : null,
+            children: Array.from(answerContainers.at(-1).children).map(describe),
+          }
+        : null,
+      textareas: textareas.map((element) => ({
+        ...describe(element),
+        valueLength: element.value.length,
+        placeholder: element.getAttribute("placeholder"),
+      })),
+      submitButtons,
+      generationSignals,
+      latestAnswerStructure,
+      possibleChatControls: controls,
+    };
+  });
+}
+
+async function settleChatHistory() {
+  const jumpButton = page.locator("button.jump-to-bottom-button");
+  if ((await jumpButton.count()) > 0 && (await jumpButton.isVisible().catch(() => false))) {
+    await jumpButton.click();
+  }
+
+  const latestMessage = page.locator("chat-message").last();
+  if ((await latestMessage.count()) > 0) {
+    await latestMessage.scrollIntoViewIfNeeded().catch(() => undefined);
+  }
+
+  const deadline = Date.now() + 15_000;
+  let previousSignature = "";
+  let stablePolls = 0;
+
+  while (Date.now() < deadline) {
+    const current = await inspectChat();
+    const signature = [
+      current.answerContainerCount,
+      current.answerTextCount,
+      compactText(current.latestAnswer, 160),
+    ].join("|");
+
+    if (signature === previousSignature) {
+      stablePolls++;
+      if (stablePolls >= 6) return current;
+    } else {
+      previousSignature = signature;
+      stablePolls = 1;
+    }
+    await page.waitForTimeout(500);
+  }
+
+  return await inspectChat();
+}
+
+try {
+  await page.goto(activeNotebook.url, {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+  await page.waitForSelector("textarea.query-box-input", {
+    state: "visible",
+    timeout: 60_000,
+  });
+
+  const before = await settleChatHistory();
+  const latestAnswerLocator = page.locator(
+    ".to-user-container:last-of-type .message-text-content"
+  );
+  console.log(
+    JSON.stringify(
+      {
+        ...before,
+        latestAnswer: compactText(before.latestAnswer),
+      },
+      null,
+      2
+    )
+  );
+
+  if (process.argv.includes("--html") && (await latestAnswerLocator.count()) > 0) {
+    console.log(
+      JSON.stringify(
+        {
+          latestAnswerInnerText: await latestAnswerLocator.last().innerText(),
+          latestAnswerHtml: await latestAnswerLocator.last().innerHTML(),
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  if (process.argv.includes("--probe")) {
+    const marker = `DOM probe ${Date.now()}: responde únicamente con la palabra ESTRUCTURA.`;
+    const input = page.locator("textarea.query-box-input");
+    await input.fill(marker);
+    await input.press("Enter");
+
+    const transitions = [];
+    const deadline = Date.now() + 120_000;
+    let lastSignature = "";
+    let finalState = before;
+    let stableAnswerPolls = 0;
+    let lastAnswer = "";
+
+    while (Date.now() < deadline) {
+      const current = await inspectChat();
+      const signature = [
+        current.answerContainerCount,
+        current.answerTextCount,
+        compactText(current.latestAnswer, 80),
+      ].join("|");
+
+      if (signature !== lastSignature) {
+        const latestAssistant = current.assistantMessages.at(-1);
+        transitions.push({
+          elapsedMs: 120_000 - (deadline - Date.now()),
+          answerContainerCount: current.answerContainerCount,
+          answerTextCount: current.answerTextCount,
+          latestAnswer: compactText(current.latestAnswer),
+          latestHasActions: latestAssistant?.hasActions ?? false,
+          submitButtons: current.submitButtons,
+          generationSignals: current.generationSignals,
+        });
+        lastSignature = signature;
+      }
+
+      finalState = current;
+      const hasNewAnswer =
+        current.answerTextCount > before.answerTextCount &&
+        compactText(current.latestAnswer) !== compactText(before.latestAnswer);
+      const looksLikePlaceholder =
+        current.latestAnswer.length < 120 && current.latestAnswer.trim().endsWith("...");
+      const hasFinalActions = current.assistantMessages.at(-1)?.hasActions === true;
+
+      if (hasNewAnswer && !looksLikePlaceholder && hasFinalActions) {
+        if (current.latestAnswer === lastAnswer) {
+          stableAnswerPolls++;
+          if (stableAnswerPolls >= 6) break;
+        } else {
+          lastAnswer = current.latestAnswer;
+          stableAnswerPolls = 1;
+        }
+      } else {
+        stableAnswerPolls = 0;
+        lastAnswer = "";
+      }
+      await page.waitForTimeout(500);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          probe: marker,
+          inputCleared: (await input.inputValue()) === "",
+          transitions,
+          final: {
+            answerContainerCount: finalState.answerContainerCount,
+            answerTextCount: finalState.answerTextCount,
+            latestAnswer: compactText(finalState.latestAnswer),
+            latestAssistant: finalState.assistantMessages.at(-1),
+            submitButtons: finalState.submitButtons,
+            generationSignals: finalState.generationSignals,
+          },
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  if (process.argv.includes("--menu")) {
+    const menuButton = page.getByRole("button", { name: "Opciones de chat" });
+    await menuButton.click();
+    await page.waitForTimeout(300);
+    const menuItems = await page
+      .locator("[role='menuitem'], .mat-mdc-menu-item")
+      .evaluateAll((elements) =>
+        elements.map((element) => ({
+          tag: element.tagName.toLowerCase(),
+          className: element.className || "",
+          ariaLabel: element.getAttribute("aria-label"),
+          role: element.getAttribute("role"),
+          text: (element.textContent || "").replace(/\s+/g, " ").trim(),
+        }))
+      );
+    console.log(JSON.stringify({ chatMenuItems: menuItems }, null, 2));
+  }
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/scripts/mcp-client.mjs
+++ b/scripts/mcp-client.mjs
@@ -1,0 +1,69 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const endpoint = new URL(process.env.NOTEBOOKLM_MCP_URL ?? "http://127.0.0.1:3000/mcp");
+const action = process.argv[2] ?? "health";
+const client = new Client({ name: "notebooklm-mcp-local-client", version: "1.0.0" });
+
+function printToolResult(result) {
+  const text = result.content
+    ?.filter((item) => item.type === "text")
+    .map((item) => item.text)
+    .join("\n");
+
+  if (text) {
+    console.log(text);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+try {
+  await client.connect(new StreamableHTTPClientTransport(endpoint));
+  const tools = await client.listTools();
+  console.log(`Connected to ${endpoint.href}`);
+  console.log(`Available tools: ${tools.tools.length}`);
+
+  if (action === "health") {
+    printToolResult(await client.callTool({ name: "get_health", arguments: {} }));
+  } else if (action === "auth") {
+    console.log("Opening the interactive Google authentication flow...");
+    printToolResult(
+      await client.callTool(
+        {
+          name: "setup_auth",
+          arguments: { show_browser: true },
+        },
+        undefined,
+        {
+          timeout: 600_000,
+          resetTimeoutOnProgress: true,
+          maxTotalTimeout: 650_000,
+        }
+      )
+    );
+  } else if (action === "ask") {
+    const question =
+      process.argv.slice(3).join(" ").trim() ||
+      "Responde únicamente: sesión de NotebookLM funcionando.";
+    console.log(`Question: ${question}`);
+    printToolResult(
+      await client.callTool(
+        {
+          name: "ask_question",
+          arguments: { question },
+        },
+        undefined,
+        {
+          timeout: 180_000,
+          resetTimeoutOnProgress: true,
+          maxTotalTimeout: 240_000,
+        }
+      )
+    );
+  } else {
+    throw new Error(`Unknown action "${action}". Use "health", "auth", or "ask".`);
+  }
+} finally {
+  await client.close();
+}

--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -16,7 +16,7 @@ import type { BrowserContext, ElementHandle, Page } from "patchright";
 import fs from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { CONFIG, NOTEBOOKLM_AUTH_URL } from "../config.js";
+import { CONFIG, NOTEBOOKLM_AUTH_URL, getRuntimeConfig } from "../config.js";
 import { log } from "../utils/logger.js";
 import {
   getPreferredChannel,
@@ -30,6 +30,7 @@ import {
   randomMouseMovement,
 } from "../utils/stealth-utils.js";
 import type { ProgressCallback } from "../types.js";
+import { isNotebookLmPageUrl } from "../notebooklm/url.js";
 
 /**
  * Critical cookie names for Google authentication
@@ -45,6 +46,10 @@ const CRITICAL_COOKIE_NAMES = [
   "__Secure-1PSID",
   "__Secure-3PSID", // Secure variants
 ];
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
 
 export class AuthManager {
   private stateFilePath: string;
@@ -66,6 +71,7 @@ export class AuthManager {
     try {
       // Save storage state (cookies + localStorage + IndexedDB)
       await context.storageState({ path: this.stateFilePath });
+      await fs.chmod(this.stateFilePath, 0o600).catch(() => undefined);
 
       // Also save sessionStorage if page is provided
       if (page) {
@@ -84,6 +90,7 @@ export class AuthManager {
 
           await fs.writeFile(this.sessionFilePath, sessionStorageData, {
             encoding: "utf-8",
+            mode: 0o600,
           });
 
           const entries = Object.keys(JSON.parse(sessionStorageData)).length;
@@ -282,6 +289,7 @@ export class AuthManager {
    */
   async performLogin(page: Page, sendProgress?: ProgressCallback): Promise<boolean> {
     try {
+      const context = page.context();
       log.info("🌐 Opening Google login page...");
       log.warning("📝 Please login to your Google account");
       log.warning("⏳ Browser will close automatically once you reach NotebookLM");
@@ -305,7 +313,8 @@ export class AuthManager {
 
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         try {
-          const currentUrl = page.url();
+          const livePages = context.pages().filter((candidate) => !candidate.isClosed());
+          const notebookPage = livePages.find((candidate) => isNotebookLmPageUrl(candidate.url()));
           const elapsedSeconds = Math.floor(attempt * (checkIntervalMs / 1000));
 
           // Send progress every 10 seconds
@@ -319,39 +328,48 @@ export class AuthManager {
             );
           }
 
-          // ✅ SIMPLE: Check if we're on NotebookLM (any path!)
-          if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+          // Google can replace the login tab or open NotebookLM in a new one.
+          // Inspect the entire persistent context instead of only the initial page.
+          if (notebookPage) {
             await sendProgress?.("Login successful! NotebookLM detected!", 9, 10);
             log.success("✅ Login successful! NotebookLM URL detected.");
-            log.success(`✅ Current URL: ${currentUrl}`);
+            log.success(`✅ Current URL: ${notebookPage.url()}`);
 
             // Short wait to ensure page is loaded
-            await page.waitForTimeout(2000);
+            await wait(2000);
             return true;
           }
 
-          // Still on accounts.google.com - log periodically
-          if (currentUrl.includes("accounts.google.com") && attempt % 30 === 0 && attempt > 0) {
-            log.warning(`⏳ Still waiting... (${elapsedSeconds}s elapsed)`);
+          if (livePages.length === 0) {
+            log.error("❌ Login browser was closed before NotebookLM was detected");
+            return false;
           }
 
-          await page.waitForTimeout(checkIntervalMs);
-        } catch {
-          await page.waitForTimeout(checkIntervalMs);
+          if (attempt % 10 === 0 && attempt > 0) {
+            const currentUrls = livePages.map((candidate) => candidate.url());
+            log.warning(`⏳ Still waiting... (${elapsedSeconds}s elapsed)`);
+            log.info(`  Open pages: ${currentUrls.join(" | ")}`);
+          }
+
+          await wait(checkIntervalMs);
+        } catch (error) {
+          log.warning(`⚠️  Login check failed temporarily: ${error}`);
+          await wait(checkIntervalMs);
           continue;
         }
       }
 
       // Timeout reached - final check
-      const currentUrl = page.url();
-      if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+      const notebookPage = context
+        .pages()
+        .find((candidate) => !candidate.isClosed() && isNotebookLmPageUrl(candidate.url()));
+      if (notebookPage) {
         await sendProgress?.("Login successful (detected on timeout check)!", 9, 10);
         log.success("✅ Login successful (detected on timeout check)");
         return true;
       }
 
       log.error("❌ Login verification failed - timeout reached");
-      log.warning(`Current URL: ${currentUrl}`);
       return false;
     } catch (error) {
       log.error(`❌ Login failed: ${error}`);
@@ -376,7 +394,7 @@ export class AuthManager {
     log.warning(`🔁 Attempting automatic login for ${maskedEmail}...`);
 
     // Log browser visibility
-    if (!CONFIG.headless) {
+    if (!getRuntimeConfig().headless) {
       log.info("  👁️  Browser is VISIBLE for debugging");
     } else {
       log.info("  🙈 Browser is HEADLESS (invisible)");
@@ -387,19 +405,19 @@ export class AuthManager {
     try {
       await page.goto(NOTEBOOKLM_AUTH_URL, {
         waitUntil: "domcontentloaded",
-        timeout: CONFIG.browserTimeout,
+        timeout: getRuntimeConfig().browserTimeout,
       });
       log.success(`  ✅ Page loaded: ${page.url().slice(0, 80)}...`);
     } catch {
       log.warning(`  ⚠️  Page load timeout (continuing anyway)`);
     }
 
-    const deadline = Date.now() + CONFIG.autoLoginTimeoutMs;
-    log.info(`  ⏰ Auto-login timeout: ${CONFIG.autoLoginTimeoutMs / 1000}s`);
+    const deadline = Date.now() + getRuntimeConfig().autoLoginTimeoutMs;
+    log.info(`  ⏰ Auto-login timeout: ${getRuntimeConfig().autoLoginTimeoutMs / 1000}s`);
 
     // Already on NotebookLM?
     log.info("  🔍 Checking if already authenticated...");
-    if (await this.waitForNotebook(page, CONFIG.autoLoginTimeoutMs)) {
+    if (await this.waitForNotebook(page, getRuntimeConfig().autoLoginTimeoutMs)) {
       log.success("✅ Already authenticated");
       await this.saveBrowserState(context, page);
       return true;
@@ -411,7 +429,7 @@ export class AuthManager {
     log.info("  🔍 Checking for account chooser...");
     if (await this.handleAccountChooser(page, email)) {
       log.success("  ✅ Account selected from chooser");
-      if (await this.waitForNotebook(page, CONFIG.autoLoginTimeoutMs)) {
+      if (await this.waitForNotebook(page, getRuntimeConfig().autoLoginTimeoutMs)) {
         log.success("✅ Automatic login successful");
         await this.saveBrowserState(context, page);
         return true;
@@ -421,7 +439,7 @@ export class AuthManager {
     // Email step
     log.info("  📧 Entering email address...");
     if (!(await this.fillIdentifier(page, email))) {
-      if (await this.waitForNotebook(page, CONFIG.autoLoginTimeoutMs)) {
+      if (await this.waitForNotebook(page, getRuntimeConfig().autoLoginTimeoutMs)) {
         log.success("✅ Automatic login successful");
         await this.saveBrowserState(context, page);
         return true;
@@ -467,7 +485,10 @@ export class AuthManager {
 
     // Take screenshot for debugging
     try {
-      const screenshotPath = path.join(CONFIG.dataDir, `login_failed_${Date.now()}.png`);
+      const screenshotPath = path.join(
+        getRuntimeConfig().dataDir,
+        `login_failed_${Date.now()}.png`
+      );
       await page.screenshot({ path: screenshotPath });
       log.info(`  📸 Screenshot saved: ${screenshotPath}`);
     } catch (error) {
@@ -491,7 +512,7 @@ export class AuthManager {
       } else {
         log.error(`  ❌ Stuck on Google accounts page: ${currentUrl.slice(0, 80)}...`);
       }
-    } else if (currentUrl.includes("notebooklm.google.com")) {
+    } else if (isNotebookLmPageUrl(currentUrl)) {
       log.warning("  ⚠️  Reached NotebookLM but couldn't detect successful login");
       log.info("  💡 This might be a timing issue - try again");
     } else {
@@ -519,7 +540,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookLmPageUrl(currentUrl)) {
           log.success("    ✅ NotebookLM URL detected!");
           // Short wait to ensure page is loaded
           await page.waitForTimeout(2000);
@@ -550,7 +571,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookLmPageUrl(currentUrl)) {
           log.success("  ✅ NotebookLM URL detected");
           return true;
         }
@@ -673,9 +694,8 @@ export class AuthManager {
     // ✅ FASTER: Programmer typing speed (90-120 WPM from config)
     log.info(`    ⌨️  Typing email: ${this.maskEmail(email)}`);
     try {
-      const wpm =
-        CONFIG.typingWpmMin +
-        Math.floor(Math.random() * (CONFIG.typingWpmMax - CONFIG.typingWpmMin + 1));
+      const { typingWpmMin, typingWpmMax } = getRuntimeConfig();
+      const wpm = typingWpmMin + Math.floor(Math.random() * (typingWpmMax - typingWpmMin + 1));
       await humanType(page, emailSelector, email, { wpm, withTypos: false });
       log.success("    ✅ Email typed successfully");
     } catch (error) {
@@ -776,9 +796,8 @@ export class AuthManager {
     // ✅ FASTER: Programmer typing speed (90-120 WPM from config)
     log.info("    ⌨️  Typing password...");
     try {
-      const wpm =
-        CONFIG.typingWpmMin +
-        Math.floor(Math.random() * (CONFIG.typingWpmMax - CONFIG.typingWpmMin + 1));
+      const { typingWpmMin, typingWpmMax } = getRuntimeConfig();
+      const wpm = typingWpmMin + Math.floor(Math.random() * (typingWpmMax - typingWpmMin + 1));
       if (passwordSelector) {
         await humanType(page, passwordSelector, password, { wpm, withTypos: false });
       }
@@ -916,21 +935,16 @@ export class AuthManager {
     const shouldShowBrowser = overrideHeadless !== undefined ? overrideHeadless : true;
 
     try {
-      // CRITICAL: Clear ALL old auth data FIRST (for account switching)
-      log.info("🔄 Preparing for new account authentication...");
-      await sendProgress?.("Clearing old authentication data...", 1, 10);
-      await this.clearAllAuthData();
-
       log.info("🚀 Launching persistent browser for interactive setup...");
-      log.info(`  📍 Profile: ${CONFIG.chromeProfileDir}`);
-      await sendProgress?.("Launching persistent browser...", 2, 10);
+      log.info(`  📍 Profile: ${getRuntimeConfig().chromeProfileDir}`);
+      await sendProgress?.("Launching persistent browser...", 1, 10);
 
       // ✅ CRITICAL FIX: Use launchPersistentContext (same as runtime!)
       // This ensures session cookies persist correctly. Channel selection +
       // fallback shared with the runtime context manager (issues #13, #19).
       const baseLaunchOptions = {
         headless: !shouldShowBrowser,
-        viewport: CONFIG.viewport,
+        viewport: getRuntimeConfig().viewport,
         locale: "en-US",
         timezoneId: "Europe/Berlin",
         args: [
@@ -944,14 +958,14 @@ export class AuthManager {
       let context: BrowserContext;
       try {
         context = await chromium.launchPersistentContext(
-          CONFIG.chromeProfileDir,
+          getRuntimeConfig().chromeProfileDir,
           withChannel(baseLaunchOptions, preferred)
         );
       } catch (err) {
         if (preferred === "chrome" && isChannelFailure(err)) {
           log.warning("⚠️  System Chrome failed to launch — falling back to bundled Chromium.");
           context = await chromium.launchPersistentContext(
-            CONFIG.chromeProfileDir,
+            getRuntimeConfig().chromeProfileDir,
             withChannel(baseLaunchOptions, "chromium")
           );
         } else {
@@ -970,10 +984,15 @@ export class AuthManager {
         // ✅ Save browser state to state.json (for validation & backup)
         // Chrome ALSO saves everything to the persistent profile automatically!
         await sendProgress?.("Saving authentication state...", 9, 10);
-        await this.saveBrowserState(context, page);
+        const authenticatedPage =
+          context
+            .pages()
+            .find((candidate) => !candidate.isClosed() && isNotebookLmPageUrl(candidate.url())) ??
+          page;
+        await this.saveBrowserState(context, authenticatedPage);
         log.success("✅ Setup complete - authentication saved to:");
         log.success(`  📄 State file: ${this.stateFilePath}`);
-        log.success(`  📁 Chrome profile: ${CONFIG.chromeProfileDir}`);
+        log.success(`  📁 Chrome profile: ${getRuntimeConfig().chromeProfileDir}`);
         log.info("💡 Session cookies will now persist across restarts!");
       }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,6 +192,8 @@ function parseProfileStrategy(
  * Apply environment variable overrides (legacy support)
  */
 function applyEnvOverrides(config: Config): Config {
+  const dataDir = process.env.NOTEBOOKLM_DATA_DIR || config.dataDir;
+
   return {
     ...config,
     // Override with env vars if present
@@ -219,6 +221,10 @@ function applyEnvOverrides(config: Config): Config {
     typingWpmMax: parseInteger(process.env.TYPING_WPM_MAX, config.typingWpmMax),
     minDelayMs: parseInteger(process.env.MIN_DELAY_MS, config.minDelayMs),
     maxDelayMs: parseInteger(process.env.MAX_DELAY_MS, config.maxDelayMs),
+    dataDir,
+    browserStateDir: path.join(dataDir, "browser_state"),
+    chromeProfileDir: path.join(dataDir, "chrome_profile"),
+    chromeInstancesDir: path.join(dataDir, "chrome_profile_instances"),
     notebookDescription: process.env.NOTEBOOK_DESCRIPTION || config.notebookDescription,
     notebookTopics: parseArray(process.env.NOTEBOOK_TOPICS, config.notebookTopics),
     notebookContentTypes: parseArray(

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@
 import envPaths from "env-paths";
 import fs from "fs";
 import path from "path";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 // Cross-platform data paths (unified without -nodejs suffix)
 // Linux: ~/.local/share/notebooklm-mcp/
@@ -25,7 +26,7 @@ const paths = envPaths("notebooklm-mcp", { suffix: "" });
  * This is the base Google login URL that redirects to NotebookLM
  */
 export const NOTEBOOKLM_AUTH_URL =
-  "https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fnotebooklm.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin";
+  "https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fnotebook.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin";
 
 export interface Config {
   // NotebookLM - optional, used for legacy default notebook
@@ -267,6 +268,23 @@ function buildConfig(): Config {
 export const CONFIG: Config = buildConfig();
 
 /**
+ * Request-scoped configuration.
+ *
+ * Browser tool calls may run concurrently when the HTTP transport is used.
+ * Keeping overrides in AsyncLocalStorage prevents one request from mutating
+ * the process-wide CONFIG object while another request is still running.
+ */
+const runtimeConfigStorage = new AsyncLocalStorage<Config>();
+
+export function getRuntimeConfig(): Config {
+  return runtimeConfigStorage.getStore() ?? CONFIG;
+}
+
+export function withRuntimeConfig<T>(config: Config, operation: () => Promise<T>): Promise<T> {
+  return runtimeConfigStorage.run(config, operation);
+}
+
+/**
  * Ensure all required directories exist
  * NOTE: We do NOT create configDir - it's not needed!
  */
@@ -292,6 +310,7 @@ export interface BrowserOptions {
   show?: boolean;
   headless?: boolean;
   timeout_ms?: number;
+  answer_timeout_ms?: number;
   stealth?: {
     enabled?: boolean;
     random_delays?: boolean;
@@ -330,6 +349,9 @@ export function applyBrowserOptions(options?: BrowserOptions, legacyShowBrowser?
     if (options.timeout_ms !== undefined) {
       config.browserTimeout = options.timeout_ms;
     }
+    if (options.answer_timeout_ms !== undefined) {
+      config.answerTimeoutMs = options.answer_timeout_ms;
+    }
     if (options.stealth) {
       const s = options.stealth;
       if (s.enabled !== undefined) config.stealthEnabled = s.enabled;
@@ -351,6 +373,3 @@ export function applyBrowserOptions(options?: BrowserOptions, legacyShowBrowser?
 
   return config;
 }
-
-// Create directories on import
-ensureDirectories();

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ import { ResourceHandlers } from "./resources/resource-handlers.js";
 import { SettingsManager } from "./utils/settings-manager.js";
 import { CliHandler } from "./utils/cli-handler.js";
 import { CONFIG, ensureDirectories } from "./config.js";
-import { startHttpTransport } from "./transport/http.js";
+import { startHttpTransport, type HttpTransportHandle } from "./transport/http.js";
 import { log } from "./utils/logger.js";
 
 /**
@@ -139,7 +139,6 @@ function extractProgressToken(
  * Main MCP Server Class
  */
 class NotebookLMMCPServer {
-  private server: Server;
   private authManager: AuthManager;
   private sessionManager: SessionManager;
   private library: NotebookLibrary;
@@ -147,46 +146,22 @@ class NotebookLMMCPServer {
   private resourceHandlers: ResourceHandlers;
   private settingsManager: SettingsManager;
   private toolDefinitions: Tool[];
+  private connectedServers = new Set<Server>();
+  private httpHandle?: HttpTransportHandle;
 
   constructor() {
-    // Initialize MCP Server
-    this.server = new Server(
-      {
-        name: "notebooklm-mcp",
-        version: "2.0.0",
-      },
-      {
-        capabilities: {
-          tools: {},
-          resources: {},
-          resourceTemplates: {},
-          prompts: {},
-          completions: {}, // Required for completion/complete support
-          logging: {},
-        },
-        // MCP-spec server instructions (clients merge into the system prompt).
-        // Use these for cross-tool workflow guidance — do not duplicate
-        // information that already lives in individual tool descriptions.
-        instructions: SERVER_INSTRUCTIONS,
-      }
-    );
-
-    // Initialize managers
+    // Initialize managers shared by all MCP protocol sessions.
     this.authManager = new AuthManager();
     this.sessionManager = new SessionManager(this.authManager);
     this.library = new NotebookLibrary();
     this.settingsManager = new SettingsManager();
 
-    // Initialize handlers
     this.toolHandlers = new ToolHandlers(this.sessionManager, this.authManager, this.library);
     this.resourceHandlers = new ResourceHandlers(this.library);
 
-    // Build and Filter tool definitions
     const allTools = buildToolDefinitions(this.library) as Tool[];
     this.toolDefinitions = this.settingsManager.filterTools(allTools);
 
-    // Setup handlers
-    this.setupHandlers();
     this.setupShutdownHandlers();
 
     const activeSettings = this.settingsManager.getEffectiveSettings();
@@ -197,15 +172,43 @@ class NotebookLMMCPServer {
     log.info(`  Profile: ${activeSettings.profile} (${this.toolDefinitions.length} tools active)`);
   }
 
+  private createProtocolServer(): Server {
+    const server = new Server(
+      {
+        name: "notebooklm-mcp",
+        version: "2.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+          resources: {},
+          prompts: {},
+          completions: {}, // Required for completion/complete support
+          logging: {},
+        },
+        // MCP-spec server instructions (clients merge into the system prompt).
+        // Use these for cross-tool workflow guidance — do not duplicate
+        // information that already lives in individual tool descriptions.
+        instructions: SERVER_INSTRUCTIONS,
+      }
+    );
+    this.setupHandlers(server);
+    this.connectedServers.add(server);
+    server.onclose = () => {
+      this.connectedServers.delete(server);
+    };
+    return server;
+  }
+
   /**
    * Setup MCP request handlers
    */
-  private setupHandlers(): void {
+  private setupHandlers(server: Server): void {
     // Register Resource Handlers (Resources, Templates, Completions)
-    this.resourceHandlers.registerHandlers(this.server);
+    this.resourceHandlers.registerHandlers(server);
 
     // List available tools
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
       log.info("📋 [MCP] list_tools request received");
       return {
         tools: this.toolDefinitions,
@@ -213,28 +216,34 @@ class NotebookLMMCPServer {
     });
 
     // Handle tool calls
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
       const { name, arguments: args } = request.params;
       const progressToken = extractProgressToken(args);
 
       log.info(`🔧 [MCP] Tool call: ${name}`);
-      if (progressToken) {
+      if (progressToken !== undefined) {
         log.info(`  📊 Progress token: ${progressToken}`);
       }
 
       // Create progress callback function
       const sendProgress = async (message: string, progress?: number, total?: number) => {
-        if (progressToken) {
-          await this.server.notification({
-            method: "notifications/progress",
-            params: {
-              progressToken,
-              message,
-              ...(progress !== undefined && { progress }),
-              ...(total !== undefined && { total }),
-            },
-          });
-          log.dim(`  📊 Progress: ${message}`);
+        if (progressToken !== undefined) {
+          try {
+            await extra.sendNotification({
+              method: "notifications/progress",
+              params: {
+                progressToken,
+                message,
+                ...(progress !== undefined && { progress }),
+                ...(total !== undefined && { total }),
+              },
+            });
+            log.dim(`  📊 Progress: ${message}`);
+          } catch (error) {
+            // Progress is best-effort. Losing an Inspector/client connection
+            // must not cancel authentication or another long operation.
+            log.warning(`⚠️  Could not deliver progress notification: ${error}`);
+          }
         }
       };
 
@@ -409,6 +418,7 @@ class NotebookLMMCPServer {
                   ),
                 },
               ],
+              isError: true,
             };
         }
 
@@ -420,6 +430,7 @@ class NotebookLMMCPServer {
               text: JSON.stringify(result, null, 2),
             },
           ],
+          isError: result.success === false,
         };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -439,6 +450,7 @@ class NotebookLMMCPServer {
               ),
             },
           ],
+          isError: true,
         };
       }
     });
@@ -468,8 +480,15 @@ class NotebookLMMCPServer {
       watchdog.unref();
 
       try {
+        if (this.httpHandle) {
+          await this.httpHandle.close();
+          this.httpHandle = undefined;
+        }
         await this.toolHandlers.cleanup();
-        await this.server.close();
+        for (const server of Array.from(this.connectedServers)) {
+          await server.close();
+        }
+        this.connectedServers.clear();
         log.success("✅ Shutdown complete");
         clearTimeout(watchdog);
         process.exit(0);
@@ -517,17 +536,31 @@ class NotebookLMMCPServer {
     log.info("");
 
     if (options.kind === "http") {
-      await startHttpTransport({
+      this.httpHandle = await startHttpTransport({
         port: options.port,
         host: options.host,
+        authToken: process.env.NOTEBOOKLM_HTTP_AUTH_TOKEN,
+        allowedOrigins: parseCsvEnv(process.env.NOTEBOOKLM_ALLOWED_ORIGINS),
+        allowedHosts: parseCsvEnv(process.env.NOTEBOOKLM_ALLOWED_HOSTS),
+        maxBodyBytes: parsePositiveIntegerEnv(
+          process.env.NOTEBOOKLM_HTTP_MAX_BODY_BYTES,
+          1024 * 1024
+        ),
         connect: async (transport) => {
-          await this.server.connect(transport);
+          const server = this.createProtocolServer();
+          try {
+            await server.connect(transport);
+          } catch (error) {
+            this.connectedServers.delete(server);
+            throw error;
+          }
         },
       });
       log.success("✅ MCP Server connected via Streamable HTTP");
     } else {
       const transport = new StdioServerTransport();
-      await this.server.connect(transport);
+      const server = this.createProtocolServer();
+      await server.connect(transport);
       log.success("✅ MCP Server connected via stdio");
     }
 
@@ -546,10 +579,29 @@ class NotebookLMMCPServer {
 
 type TransportOptions = { kind: "stdio" } | { kind: "http"; port: number; host?: string };
 
+function parseCsvEnv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const values = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return values.length > 0 ? values : undefined;
+}
+
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function parseTransportOptions(argv: readonly string[]): TransportOptions {
-  let kind: "stdio" | "http" = "stdio";
-  let port = 3000;
-  let host: string | undefined;
+  const envTransport = process.env.NOTEBOOKLM_TRANSPORT;
+  let kind: "stdio" | "http" =
+    envTransport === "http" || envTransport === "stdio" ? envTransport : "stdio";
+  const envPort = process.env.NOTEBOOKLM_PORT;
+  let port = envPort ? Number.parseInt(envPort, 10) : 3000;
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) port = 3000;
+  let host: string | undefined = process.env.NOTEBOOKLM_HOST;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -583,18 +635,12 @@ function parseTransportOptions(argv: readonly string[]): TransportOptions {
     }
   }
 
-  // Env-var fallbacks for hosted deployments.
-  const envTransport = process.env.NOTEBOOKLM_TRANSPORT;
-  if (envTransport === "http" || envTransport === "stdio") kind = envTransport;
-  const envPort = process.env.NOTEBOOKLM_PORT;
-  if (envPort) {
-    const parsed = Number.parseInt(envPort, 10);
-    if (Number.isFinite(parsed)) port = parsed;
+  if (kind === "http") {
+    if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+      throw new Error(`Invalid HTTP port: ${port}. Expected an integer from 1 to 65535.`);
+    }
+    return { kind, port, host };
   }
-  const envHost = process.env.NOTEBOOKLM_HOST;
-  if (envHost) host = envHost;
-
-  if (kind === "http") return { kind, port, host };
   return { kind: "stdio" };
 }
 
@@ -616,9 +662,9 @@ async function main() {
   const account = getRequestedAccount();
   if (account) {
     applyAccountToConfig(CONFIG, account);
-    ensureDirectories();
     log.info(`👤 Account profile active: ${account}`);
   }
+  ensureDirectories();
 
   // Print banner
   console.error("╔══════════════════════════════════════════════════════════╗");

--- a/src/library/notebook-library.ts
+++ b/src/library/notebook-library.ts
@@ -17,6 +17,29 @@ import type {
   UpdateNotebookInput,
   LibraryStats,
 } from "./types.js";
+import { normalizeNotebookUrl } from "../notebooklm/url.js";
+import { z } from "zod";
+
+const notebookEntrySchema = z.object({
+  id: z.string().min(1),
+  url: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().default(""),
+  topics: z.array(z.string()).default([]),
+  content_types: z.array(z.string()).default([]),
+  use_cases: z.array(z.string()).default([]),
+  added_at: z.string(),
+  last_used: z.string(),
+  use_count: z.number().int().nonnegative().default(0),
+  tags: z.array(z.string()).optional(),
+});
+
+const librarySchema = z.object({
+  notebooks: z.array(notebookEntrySchema),
+  active_notebook_id: z.string().nullable(),
+  last_modified: z.string(),
+  version: z.string(),
+});
 
 export class NotebookLibrary {
   private libraryPath: string;
@@ -41,12 +64,17 @@ export class NotebookLibrary {
     try {
       if (fs.existsSync(this.libraryPath)) {
         const data = fs.readFileSync(this.libraryPath, "utf-8");
-        const library = JSON.parse(data) as Library;
+        const library = librarySchema.parse(JSON.parse(data)) as Library;
         log.success(`  ✅ Loaded library with ${library.notebooks.length} notebooks`);
         return library;
       }
     } catch (error) {
       log.warning(`  ⚠️  Failed to load library: ${error}`);
+      if (fs.existsSync(this.libraryPath)) {
+        const backupPath = `${this.libraryPath}.corrupt-${Date.now()}`;
+        fs.copyFileSync(this.libraryPath, backupPath);
+        log.warning(`  🛟 Preserved unreadable library at: ${backupPath}`);
+      }
     }
 
     // Create default library with current CONFIG as first entry
@@ -100,13 +128,18 @@ export class NotebookLibrary {
    * Save library to disk
    */
   private saveLibrary(library: Library): void {
+    const temporaryPath = `${this.libraryPath}.${process.pid}.tmp`;
     try {
       library.last_modified = new Date().toISOString();
       const data = JSON.stringify(library, null, 2);
-      fs.writeFileSync(this.libraryPath, data, "utf-8");
+      fs.writeFileSync(temporaryPath, data, { encoding: "utf-8", mode: 0o600 });
+      fs.renameSync(temporaryPath, this.libraryPath);
       this.library = library;
       log.success(`  💾 Library saved (${library.notebooks.length} notebooks)`);
     } catch (error) {
+      if (fs.existsSync(temporaryPath)) {
+        fs.unlinkSync(temporaryPath);
+      }
       log.error(`  ❌ Failed to save library: ${error}`);
       throw error;
     }
@@ -138,6 +171,7 @@ export class NotebookLibrary {
    */
   addNotebook(input: AddNotebookInput): NotebookEntry {
     log.info(`📝 Adding notebook: ${input.name}`);
+    const normalizedUrl = normalizeNotebookUrl(input.url);
 
     // Generate ID
     const id = this.generateId(input.name);
@@ -145,7 +179,7 @@ export class NotebookLibrary {
     // Create entry
     const notebook: NotebookEntry = {
       id,
-      url: input.url,
+      url: normalizedUrl,
       name: input.name,
       description: input.description,
       topics: input.topics,
@@ -161,7 +195,7 @@ export class NotebookLibrary {
     };
 
     // Add to library
-    const updated = { ...this.library };
+    const updated = { ...this.library, notebooks: [...this.library.notebooks] };
     updated.notebooks.push(notebook);
 
     // Set as active if it's the first notebook
@@ -210,7 +244,7 @@ export class NotebookLibrary {
 
     log.info(`🎯 Selecting notebook: ${id}`);
 
-    const updated = { ...this.library };
+    const updated = { ...this.library, notebooks: [...this.library.notebooks] };
     updated.active_notebook_id = id;
 
     // Update last_used
@@ -237,7 +271,7 @@ export class NotebookLibrary {
 
     log.info(`📝 Updating notebook: ${input.id}`);
 
-    const updated = { ...this.library };
+    const updated = { ...this.library, notebooks: [...this.library.notebooks] };
     const index = updated.notebooks.findIndex((n) => n.id === input.id);
 
     updated.notebooks[index] = {
@@ -248,7 +282,7 @@ export class NotebookLibrary {
       ...(input.content_types && { content_types: input.content_types }),
       ...(input.use_cases && { use_cases: input.use_cases }),
       ...(input.tags && { tags: input.tags }),
-      ...(input.url && { url: input.url }),
+      ...(input.url && { url: normalizeNotebookUrl(input.url) }),
     };
 
     this.saveLibrary(updated);
@@ -268,7 +302,7 @@ export class NotebookLibrary {
 
     log.info(`🗑️  Removing notebook: ${id}`);
 
-    const updated = { ...this.library };
+    const updated = { ...this.library, notebooks: [...this.library.notebooks] };
     updated.notebooks = updated.notebooks.filter((n) => n.id !== id);
 
     // If we removed the active notebook, select another one
@@ -292,7 +326,7 @@ export class NotebookLibrary {
     }
 
     const notebook = this.library.notebooks[notebookIndex];
-    const updated = { ...this.library };
+    const updated = { ...this.library, notebooks: [...this.library.notebooks] };
     const updatedNotebook: NotebookEntry = {
       ...notebook,
       use_count: notebook.use_count + 1,

--- a/src/notebooklm/chat.ts
+++ b/src/notebooklm/chat.ts
@@ -1,13 +1,13 @@
 /**
- * NotebookLM chat extraction with streaming-stability detection.
+ * NotebookLM chat extraction with turn correlation and completion detection.
  *
  * Replaces the legacy `waitForLatestAnswer()` (issue #43). Old logic gated on
  * `div.thinking-message`, which Google removed; calls timed out even though
- * the answer was visible. New logic only relies on the answer container itself
- * and treats text as final once it has been *stable* across N consecutive
- * polls (default 3). That makes the wait robust to UI churn and Material-icon
- * leaks (`more_vert`, `more_horiz`, …) which would otherwise destabilise the
- * extracted text.
+ * the answer was visible. NotebookLM's current Gemini UI also renders loading
+ * phrases and private reasoning in `.message-text-content`, so text stability
+ * alone is not a completion signal. The current logic correlates an assistant
+ * card with the exact submitted user turn and only accepts it after Gemini's
+ * stop button disappears and the final `.message-actions` controls appear.
  *
  * Companion fixes:
  * - issue #14 / #27 — timeout is fully configurable per call
@@ -204,16 +204,121 @@ export interface AskOptions {
   stablePolls?: number;
 }
 
+export interface ChatMessageSnapshot {
+  role: "user" | "assistant";
+  text: string;
+  complete?: boolean;
+}
+
+interface TurnAnswerState {
+  userFound: boolean;
+  text: string | null;
+  complete: boolean;
+  generating: boolean;
+}
+
+/**
+ * Canonical form used to correlate a rendered user message with the submitted
+ * question. NotebookLM may change line wrapping while preserving the content.
+ */
+export function normalizeChatText(text: string): string {
+  return text.normalize("NFKC").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Pure turn-selection helper used by tests and the DOM extraction path.
+ * A stable but incomplete Gemini reasoning card is deliberately rejected.
+ */
+export function findCompletedTurnAnswer(
+  messages: ChatMessageSnapshot[],
+  question: string
+): string | null {
+  const expected = normalizeChatText(question);
+  let userIndex = -1;
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.role === "user" && normalizeChatText(message.text) === expected) {
+      userIndex = index;
+    }
+  }
+
+  if (userIndex < 0) return null;
+
+  for (let index = userIndex + 1; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.role === "user") return null;
+    if (message.role === "assistant") {
+      return message.complete ? sanitizeAnswer(message.text) || null : null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Scroll to the newest turn and wait briefly for NotebookLM's virtualised
+ * history to hydrate. Without this, the chat input can be ready while the DOM
+ * still reports zero prior messages.
+ */
+export async function settleChatHistory(page: Page, timeoutMs = 5_000): Promise<void> {
+  try {
+    const jumpButton = page.locator(Selectors.chat.jumpToBottomButton).first();
+    if ((await jumpButton.count()) > 0 && (await jumpButton.isVisible())) {
+      await jumpButton.click({ timeout: 2_000 });
+    }
+  } catch {
+    // The button is absent when the viewport is already at the bottom.
+  }
+
+  const messages = page.locator(Selectors.chat.message);
+  try {
+    if ((await messages.count()) > 0) {
+      await messages.last().scrollIntoViewIfNeeded({ timeout: 2_000 });
+    }
+  } catch {
+    // Hydration may replace the last element while it is being scrolled.
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let previousSignature = "";
+  let stablePolls = 0;
+
+  while (Date.now() < deadline) {
+    let signature: string;
+    try {
+      const count = await messages.count();
+      const latest = count > 0 ? normalizeChatText(await messages.last().innerText()) : "";
+      signature = `${count}|${latest}`;
+    } catch {
+      stablePolls = 0;
+      await safeSleep(page, 250);
+      continue;
+    }
+
+    if (signature === previousSignature) {
+      stablePolls++;
+      if (stablePolls >= 3) return;
+    } else {
+      previousSignature = signature;
+      stablePolls = 1;
+    }
+
+    await safeSleep(page, 250);
+  }
+}
+
 /**
  * Snapshot every visible assistant answer text *before* a new question is
  * submitted. Pass the result into `waitForStableAnswer({ ignoreTexts })` so
  * the new turn isn't confused with prior turns in the same session.
  */
 export async function snapshotPriorAnswers(page: Page): Promise<string[]> {
+  await settleChatHistory(page);
   return page
     .locator(Selectors.chat.answerText)
     .allInnerTexts()
-    .then((texts) => texts.map((t) => t.trim()).filter(Boolean))
+    .then((texts) => texts.map(sanitizeAnswer).filter(Boolean))
     .catch(() => []);
 }
 
@@ -237,8 +342,8 @@ export async function waitForStableAnswer(
   } = options;
 
   const deadline = Date.now() + timeoutMs;
-  const echoLower = question.trim().toLowerCase();
-  const ignoreSet = new Set(ignoreTexts.map((t) => t.trim()).filter(Boolean));
+  const echoText = normalizeChatText(question).toLowerCase();
+  const ignoreSet = new Set(ignoreTexts.map(sanitizeAnswer).filter(Boolean));
   // Hard ceiling on poll iterations defends against pathological
   // pollIntervalMs values combined with zombie-page sleep returns (issue #16).
   const maxPolls = Math.max(8, Math.ceil(timeoutMs / Math.max(50, pollIntervalMs)) + 4);
@@ -246,6 +351,7 @@ export async function waitForStableAnswer(
   let lastSeen: string | null = null;
   let stableStreak = 0;
   let pollCount = 0;
+  let sawGeneration = false;
 
   while (Date.now() < deadline && pollCount < maxPolls) {
     pollCount++;
@@ -256,16 +362,25 @@ export async function waitForStableAnswer(
       throw new Error("Browser page unresponsive: health check timed out");
     }
 
-    let candidate: string | null = null;
+    let state: TurnAnswerState = {
+      userFound: false,
+      text: null,
+      complete: false,
+      generating: false,
+    };
     try {
-      candidate = await readLatestAnswer(page);
+      state = question
+        ? await readAnswerForQuestion(page, question)
+        : await readLatestAnswerState(page);
     } catch (err) {
       if (isRecoverable(err)) throw err;
       // Non-fatal extraction blip — try again next tick.
     }
 
+    sawGeneration ||= state.generating;
+    const candidate = state.text;
     if (candidate) {
-      const isEcho = candidate.toLowerCase() === echoLower;
+      const isEcho = normalizeChatText(candidate).toLowerCase() === echoText;
       const isPrior = ignoreSet.has(candidate);
 
       if (!isEcho && !isPrior) {
@@ -281,20 +396,34 @@ export async function waitForStableAnswer(
 
         // Hard errors and rate-limit messages can be returned immediately —
         // there is no "stable" follow-up text coming.
-        if (isErrorMessage(candidate) || isRateLimitText(candidate)) {
+        if (!state.generating && (isErrorMessage(candidate) || isRateLimitText(candidate))) {
           return candidate;
         }
 
-        if (candidate === lastSeen) {
-          stableStreak++;
-          if (stableStreak >= stablePolls) {
-            return candidate;
+        // `.message-actions` is rendered only for a completed answer in the
+        // current UI. `sawGeneration` is a compatibility fallback for older
+        // layouts that expose the stop button but not the action row.
+        const hasCompletionSignal = state.complete || (sawGeneration && !state.generating);
+
+        if (hasCompletionSignal) {
+          if (candidate === lastSeen) {
+            stableStreak++;
+            if (stableStreak >= stablePolls) {
+              return candidate;
+            }
+          } else {
+            lastSeen = candidate;
+            stableStreak = 1;
           }
         } else {
-          lastSeen = candidate;
-          stableStreak = 1;
+          stableStreak = 0;
+          lastSeen = null;
         }
       }
+    } else if (question && state.userFound) {
+      // The user turn exists, but its assistant card has not mounted yet.
+      stableStreak = 0;
+      lastSeen = null;
     }
 
     await safeSleep(page, pollIntervalMs);
@@ -304,20 +433,127 @@ export async function waitForStableAnswer(
 }
 
 /**
- * Read the latest answer container's text and strip UI-control leakage.
- * Uses `:last-child` so we always target the most recent turn.
+ * Read the answer card immediately following the exact submitted user turn.
+ * This prevents hydrated history or an older stable card from being returned.
  */
-async function readLatestAnswer(page: Page): Promise<string | null> {
+async function readAnswerForQuestion(page: Page, question: string): Promise<TurnAnswerState> {
+  const expected = normalizeChatText(question);
+  const messages = page.locator(Selectors.chat.message);
+
   try {
-    const raw = await page
-      .locator(Selectors.chat.latestAnswerText)
-      .last()
-      .innerText({ timeout: 2_000 });
+    const match = await messages.evaluateAll((elements, expectedText) => {
+      const normalize = (value: string) => value.normalize("NFKC").replace(/\s+/g, " ").trim();
+      let userIndex = -1;
+
+      for (let index = 0; index < elements.length; index++) {
+        const user = elements[index].querySelector(".from-user-container");
+        if (user && normalize((user as HTMLElement).innerText) === expectedText) {
+          userIndex = index;
+        }
+      }
+
+      if (userIndex < 0) {
+        return { userFound: false, answerIndex: -1, complete: false };
+      }
+
+      for (let index = userIndex + 1; index < elements.length; index++) {
+        if (elements[index].querySelector(".from-user-container")) break;
+        const answer = elements[index].querySelector(".to-user-container");
+        if (answer) {
+          return {
+            userFound: true,
+            answerIndex: index,
+            complete: Boolean(answer.querySelector(".message-actions")),
+          };
+        }
+      }
+
+      return { userFound: true, answerIndex: -1, complete: false };
+    }, expected);
+
+    const generating = await isGenerating(page);
+    if (match.answerIndex < 0) {
+      return { userFound: match.userFound, text: null, complete: false, generating };
+    }
+
+    const textElement = messages
+      .nth(match.answerIndex)
+      .locator(".to-user-container .message-text-content")
+      .first();
+    const raw = await readFormattedAnswer(textElement);
     const cleaned = sanitizeAnswer(raw);
-    return cleaned.length > 0 ? cleaned : null;
+
+    return {
+      userFound: true,
+      text: cleaned || null,
+      complete: match.complete && !generating,
+      generating,
+    };
   } catch {
-    return null;
+    return { userFound: false, text: null, complete: false, generating: false };
   }
+}
+
+async function readLatestAnswerState(page: Page): Promise<TurnAnswerState> {
+  try {
+    const answers = page.locator(Selectors.chat.answerContainer);
+    if ((await answers.count()) === 0) {
+      return { userFound: false, text: null, complete: false, generating: false };
+    }
+
+    const latest = answers.last();
+    const generating = await isGenerating(page);
+    const complete = (await latest.locator(".message-actions").count()) > 0 && !generating;
+    const raw = await readFormattedAnswer(latest.locator(".message-text-content").first());
+    const cleaned = sanitizeAnswer(raw);
+    return {
+      userFound: false,
+      text: cleaned || null,
+      complete,
+      generating,
+    };
+  } catch {
+    return { userFound: false, text: null, complete: false, generating: false };
+  }
+}
+
+async function isGenerating(page: Page): Promise<boolean> {
+  const stopButton = page.locator(Selectors.chat.stopButton).first();
+  return (await stopButton.count()) > 0 && (await stopButton.isVisible().catch(() => false));
+}
+
+/**
+ * Preserve NotebookLM's rendered block layout and add Markdown markers that
+ * browser `innerText` omits for lists and inline citations.
+ */
+async function readFormattedAnswer(textElement: ReturnType<Page["locator"]>): Promise<string> {
+  return textElement.evaluate((element) => {
+    const clone = element.cloneNode(true) as HTMLElement;
+
+    clone.querySelectorAll("button.citation-marker").forEach((button) => {
+      const label = (button.textContent || "").trim();
+      const replacement = document.createTextNode(/^\d+$/.test(label) ? `[${label}]` : "");
+      button.replaceWith(replacement);
+    });
+
+    clone.querySelectorAll("ul, ol").forEach((list) => {
+      const directItems = Array.from(list.querySelectorAll("li")).filter(
+        (item) => item.closest("ul, ol") === list
+      );
+      directItems.forEach((item, index) => {
+        const prefix = list.tagName === "OL" ? `${index + 1}. ` : "- ";
+        item.prepend(document.createTextNode(prefix));
+      });
+    });
+
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText = "position:fixed;left:-100000px;top:0;width:800px;visibility:visible";
+    wrapper.appendChild(clone);
+    document.body.appendChild(wrapper);
+    const text = clone.innerText;
+    wrapper.remove();
+    return text;
+  });
 }
 
 /**
@@ -333,9 +569,13 @@ export function sanitizeAnswer(text: string): string {
     .map((line) => line.trim());
 
   const kept: string[] = [];
+  let pendingBlank = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (!line) continue;
+    if (!line) {
+      pendingBlank = kept.length > 0;
+      continue;
+    }
 
     if (Selectors.uiControlLabels.has(line)) continue;
 
@@ -348,11 +588,14 @@ export function sanitizeAnswer(text: string): string {
     if (/^\d+$/.test(line) && nextIsControl) continue;
     if (/^[.,;:!?]+$/.test(line) && (nextIsControl || prevIsControl)) continue;
 
+    if (pendingBlank && kept.at(-1) !== "") kept.push("");
     kept.push(line);
+    pendingBlank = false;
   }
 
   return kept
     .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
     .replace(/[ \t]+([.,;:!?])/g, "$1")
     .trim();
 }

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -29,9 +29,13 @@
 
 export const Selectors = {
   chat: {
+    message: "chat-message",
+    userMessage: ".from-user-container",
     answerContainer: ".to-user-container",
     answerText: ".to-user-container .message-text-content",
-    latestAnswerText: ".to-user-container:last-child .message-text-content",
+    answerActions: ".to-user-container .message-actions",
+    jumpToBottomButton: "button.jump-to-bottom-button",
+    stopButton: "button.stop-button",
     /**
      * Chat textarea. The class is shared across locales; aria-labels are a
      * fallback for older builds where the class was different.
@@ -64,6 +68,36 @@ export const Selectors = {
       'button.submit-button[aria-label*="invia" i]',
       'button.submit-button[aria-label*="verzend" i]',
       'button.submit-button[aria-label*="送信" i]',
+    ],
+    optionsButton: [
+      'button[aria-label="Chat options"]',
+      'button[aria-label="Opciones de chat"]',
+      'button[aria-label="Optionen für den Chat"]',
+      'button[aria-label="Options du chat"]',
+      'button[aria-label="Opzioni chat"]',
+      'button[aria-label="Opções do chat"]',
+      'button[aria-label="Chatopties"]',
+      'button[aria-label="チャットのオプション"]',
+    ],
+    clearHistoryMenuItem: [
+      '[role="menuitem"]:has-text("Clear chat history")',
+      '[role="menuitem"]:has-text("Borrar el historial de chat")',
+      '[role="menuitem"]:has-text("Chatverlauf löschen")',
+      '[role="menuitem"]:has-text("Effacer l’historique du chat")',
+      '[role="menuitem"]:has-text("Cancella cronologia chat")',
+      '[role="menuitem"]:has-text("Limpar histórico do chat")',
+      '[role="menuitem"]:has-text("Chatgeschiedenis wissen")',
+      '[role="menuitem"]:has-text("チャット履歴を削除")',
+    ],
+    clearHistoryConfirmButton: [
+      'button:has-text("Clear")',
+      'button:has-text("Borrar")',
+      'button:has-text("Löschen")',
+      'button:has-text("Effacer")',
+      'button:has-text("Cancella")',
+      'button:has-text("Limpar")',
+      'button:has-text("Wissen")',
+      'button:has-text("削除")',
     ],
   },
 

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -313,7 +313,7 @@ export const Selectors = {
      * contains the Download item.
      */
     audioMoreMenuButton: [
-      "artifact-library-item button:has(mat-icon:text-is(\"more_vert\"))",
+      'artifact-library-item button:has(mat-icon:text-is("more_vert"))',
       'artifact-library-item button[aria-label*="mehr" i]',
       'artifact-library-item button[aria-label*="more" i]',
       'artifact-library-item button[aria-label*="plus" i]',

--- a/src/notebooklm/sources.ts
+++ b/src/notebooklm/sources.ts
@@ -86,9 +86,7 @@ export async function addSource(page: Page, input: AddSourceInput): Promise<AddS
       const currentUrl = page.url();
       const currentUuid = currentUrl.match(/notebook\/([a-f0-9-]+)/)?.[1];
       if (currentUuid && currentUuid !== expectedUuid) {
-        log.error(
-          `  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`
-        );
+        log.error(`  ❌ Notebook redirect: expected ${expectedUuid}, got ${currentUuid}`);
         return {
           success: false,
           type: input.type,
@@ -193,17 +191,16 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
 
   // Try the sidebar button first — fastest path on a populated notebook.
   try {
-    await page
-      .locator(joinAlt(Selectors.sources.addButton))
-      .first()
-      .click({ timeout: 5_000 });
+    await page.locator(joinAlt(Selectors.sources.addButton)).first().click({ timeout: 5_000 });
     await page
       .locator(Selectors.sources.overlayPane)
       .first()
       .waitFor({ state: "visible", timeout: 8_000 });
     return;
   } catch (err) {
-    log.warning(`  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`);
+    log.warning(
+      `  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`
+    );
   }
 
   // URL fallback — useful when the sidebar button is hidden or covered.

--- a/src/notebooklm/url.ts
+++ b/src/notebooklm/url.ts
@@ -1,0 +1,37 @@
+const NOTEBOOKLM_HOSTS = new Set(["notebook.google.com", "notebooklm.google.com"]);
+const NOTEBOOK_PATH = /^\/notebook\/[a-zA-Z0-9_-]+\/?$/;
+
+export function isNotebookLmPageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && NOTEBOOKLM_HOSTS.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate and normalize a NotebookLM notebook URL before it is persisted or
+ * opened in the authenticated browser context.
+ */
+export function normalizeNotebookUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error("Notebook URL must be a valid absolute URL");
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error("Notebook URL must use HTTPS");
+  }
+  if (!NOTEBOOKLM_HOSTS.has(url.hostname.toLowerCase())) {
+    throw new Error("Notebook URL host must be notebook.google.com or notebooklm.google.com");
+  }
+  if (!NOTEBOOK_PATH.test(url.pathname)) {
+    throw new Error("Notebook URL must match https://notebook.google.com/notebook/<notebook-id>");
+  }
+
+  url.hash = "";
+  return url.toString();
+}

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -16,7 +16,7 @@
 import type { BrowserContext, Page } from "patchright";
 import type { SharedContextManager } from "./shared-context-manager.js";
 import type { AuthManager } from "../auth/auth-manager.js";
-import { humanType, randomDelay } from "../utils/stealth-utils.js";
+import { humanType, randomDelay, randomInt } from "../utils/stealth-utils.js";
 import { snapshotAllResponses } from "../utils/page-utils.js";
 import { waitForStableAnswer, snapshotPriorAnswers } from "../notebooklm/chat.js";
 import {
@@ -37,7 +37,7 @@ import {
   type AudioGenerationResult,
   type DownloadAudioResult,
 } from "../notebooklm/audio.js";
-import { CONFIG } from "../config.js";
+import { getRuntimeConfig } from "../config.js";
 import { log } from "../utils/logger.js";
 import type { SessionInfo, ProgressCallback } from "../types.js";
 import { RateLimitError } from "../errors.js";
@@ -54,6 +54,7 @@ export class BrowserSession {
   private authManager: AuthManager;
   private page: Page | null = null;
   private initialized: boolean = false;
+  private operationTail: Promise<void> = Promise.resolve();
 
   constructor(
     sessionId: string,
@@ -76,6 +77,7 @@ export class BrowserSession {
    * Initialize the session by creating a page and navigating to the notebook
    */
   async init(): Promise<void> {
+    const config = getRuntimeConfig();
     if (this.initialized) {
       log.warning(`⚠️  Session ${this.sessionId} already initialized`);
       return;
@@ -108,7 +110,7 @@ export class BrowserSession {
       log.info(`  🌐 Navigating to: ${this.notebookUrl}`);
       await this.page.goto(this.notebookUrl, {
         waitUntil: "domcontentloaded",
-        timeout: CONFIG.browserTimeout,
+        timeout: config.browserTimeout,
       });
 
       // Wait for page to stabilize
@@ -218,6 +220,7 @@ export class BrowserSession {
    * Ensure the session is authenticated, perform auto-login if needed
    */
   private async ensureAuthenticated(): Promise<boolean> {
+    const config = getRuntimeConfig();
     if (!this.page) {
       throw new Error("Page not initialized");
     }
@@ -258,13 +261,13 @@ export class BrowserSession {
     // Need fresh login
     log.warning(`  🔑 Fresh login required`);
 
-    if (CONFIG.autoLoginEnabled) {
+    if (config.autoLoginEnabled) {
       log.info(`  🤖 Attempting auto-login...`);
       const loginSuccess = await this.authManager.loginWithCredentials(
         this.context,
         this.page,
-        CONFIG.loginEmail,
-        CONFIG.loginPassword
+        config.loginEmail,
+        config.loginPassword
       );
 
       if (loginSuccess) {
@@ -360,7 +363,35 @@ export class BrowserSession {
   /**
    * Ask a question to NotebookLM
    */
+  private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationTail.then(async () => {
+      this.updateActivity();
+      return await operation();
+    });
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
   async ask(question: string, sendProgress?: ProgressCallback): Promise<string> {
+    return await this.runExclusive(() => this.askUnlocked(question, sendProgress));
+  }
+
+  async askAndExtractCitations(
+    question: string,
+    format: SourceFormat,
+    sendProgress?: ProgressCallback
+  ): Promise<ExtractCitationsResult> {
+    return await this.runExclusive(async () => {
+      const answer = await this.askUnlocked(question, sendProgress);
+      return await this.extractCitationsUnlocked(answer, format);
+    });
+  }
+
+  private async askUnlocked(question: string, sendProgress?: ProgressCallback): Promise<string> {
+    const config = getRuntimeConfig();
     const askOnce = async (): Promise<string> => {
       if (!this.initialized || !this.page || this.isPageClosedSafe()) {
         log.warning(`  ℹ️  Session not initialized or page missing → re-initializing...`);
@@ -404,7 +435,7 @@ export class BrowserSession {
       await sendProgress?.("Typing question with human-like behavior...", 2, 5);
       await humanType(page, inputSelector, question, {
         withTypos: true,
-        wpm: Math.max(CONFIG.typingWpmMin, CONFIG.typingWpmMax),
+        wpm: randomInt(config.typingWpmMin, config.typingWpmMax),
       });
 
       // Small pause before submitting
@@ -419,13 +450,13 @@ export class BrowserSession {
       await randomDelay(1000, 1500);
 
       // Wait for the response with streaming-stability detection (issue #43).
-      // Timeout comes from CONFIG.answerTimeoutMs so users can tune it via
-      // ANSWER_TIMEOUT_MS or browser_options.timeout_ms (issue #14, #27).
+      // Timeout comes from the request-scoped configuration so concurrent
+      // HTTP calls cannot overwrite one another's limits.
       log.info(`  ⏳ Waiting for response (streaming-stability)...`);
       await sendProgress?.("Waiting for NotebookLM response (streaming-stability)...", 3, 5);
       const answer = await waitForStableAnswer(page, {
         question,
-        timeoutMs: CONFIG.answerTimeoutMs,
+        timeoutMs: config.answerTimeoutMs,
         pollIntervalMs: 750,
         ignoreTexts: existingResponses,
       });
@@ -487,6 +518,10 @@ export class BrowserSession {
    * without first running `ask()`.
    */
   async addSource(input: AddSourceInput): Promise<AddSourceResult> {
+    return await this.runExclusive(() => this.addSourceUnlocked(input));
+  }
+
+  private async addSourceUnlocked(input: AddSourceInput): Promise<AddSourceResult> {
     if (!this.initialized || !this.page || this.isPageClosedSafe()) {
       await this.init();
     }
@@ -497,6 +532,12 @@ export class BrowserSession {
    * Generate an Audio Overview for the active notebook (issue #11).
    */
   async generateAudio(options: GenerateAudioOptions = {}): Promise<AudioGenerationResult> {
+    return await this.runExclusive(() => this.generateAudioUnlocked(options));
+  }
+
+  private async generateAudioUnlocked(
+    options: GenerateAudioOptions = {}
+  ): Promise<AudioGenerationResult> {
     if (!this.initialized || !this.page || this.isPageClosedSafe()) {
       await this.init();
     }
@@ -507,6 +548,10 @@ export class BrowserSession {
    * Non-blocking probe for the current Audio Overview state (issue #11).
    */
   async getAudioStatus(): Promise<AudioGenerationResult> {
+    return await this.runExclusive(() => this.getAudioStatusUnlocked());
+  }
+
+  private async getAudioStatusUnlocked(): Promise<AudioGenerationResult> {
     if (!this.initialized || !this.page || this.isPageClosedSafe()) {
       await this.init();
     }
@@ -517,6 +562,10 @@ export class BrowserSession {
    * Download the most recent Audio Overview (issue #11).
    */
   async downloadAudio(destinationDir: string): Promise<DownloadAudioResult> {
+    return await this.runExclusive(() => this.downloadAudioUnlocked(destinationDir));
+  }
+
+  private async downloadAudioUnlocked(destinationDir: string): Promise<DownloadAudioResult> {
     if (!this.initialized || !this.page || this.isPageClosedSafe()) {
       await this.init();
     }
@@ -529,6 +578,13 @@ export class BrowserSession {
    * follow-up question disturbs the source panel.
    */
   async extractCitations(answer: string, format: SourceFormat): Promise<ExtractCitationsResult> {
+    return await this.runExclusive(() => this.extractCitationsUnlocked(answer, format));
+  }
+
+  private async extractCitationsUnlocked(
+    answer: string,
+    format: SourceFormat
+  ): Promise<ExtractCitationsResult> {
     if (format === "none" || !this.page || this.isPageClosedSafe()) {
       return { citations: [], formattedAnswer: answer };
     }
@@ -739,6 +795,10 @@ export class BrowserSession {
    * Reset the chat history (start a new conversation)
    */
   async reset(): Promise<void> {
+    return await this.runExclusive(() => this.resetUnlocked());
+  }
+
+  private async resetUnlocked(): Promise<void> {
     const resetOnce = async (): Promise<void> => {
       if (!this.initialized || !this.page || this.isPageClosedSafe()) {
         await this.init();
@@ -786,6 +846,10 @@ export class BrowserSession {
    * Close the session
    */
   async close(): Promise<void> {
+    return await this.runExclusive(() => this.closeUnlocked());
+  }
+
+  private async closeUnlocked(): Promise<void> {
     log.info(`🛑 Closing session ${this.sessionId}...`);
 
     if (this.page) {

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -17,8 +17,8 @@ import type { BrowserContext, Page } from "patchright";
 import type { SharedContextManager } from "./shared-context-manager.js";
 import type { AuthManager } from "../auth/auth-manager.js";
 import { humanType, randomDelay, randomInt } from "../utils/stealth-utils.js";
-import { snapshotAllResponses } from "../utils/page-utils.js";
 import { waitForStableAnswer, snapshotPriorAnswers } from "../notebooklm/chat.js";
+import { Selectors, joinAlt } from "../notebooklm/selectors.js";
 import {
   extractCitations as extractCitationsFromPage,
   type SourceFormat,
@@ -412,14 +412,11 @@ export class BrowserSession {
         }
       }
 
-      // Snapshot existing responses BEFORE asking — uses the v2 chat module
-      // (issue #43). Falls back to the legacy snapshot only if the v2 helper
-      // produced nothing, so we don't regress when the new selectors miss.
+      // Hydrate and snapshot existing responses BEFORE asking. The current
+      // NotebookLM UI virtualises history, so the textarea can be visible
+      // before prior chat cards have mounted.
       log.info(`  📸 Snapshotting existing responses...`);
-      let existingResponses = await snapshotPriorAnswers(page);
-      if (existingResponses.length === 0) {
-        existingResponses = await snapshotAllResponses(page);
-      }
+      const existingResponses = await snapshotPriorAnswers(page);
       log.success(`  ✅ Captured ${existingResponses.length} existing responses`);
 
       // Find the chat input
@@ -441,19 +438,40 @@ export class BrowserSession {
       // Small pause before submitting
       await randomDelay(500, 1000);
 
-      // Submit the question (Enter key)
+      // Submit from the input itself so another focused control cannot consume
+      // Enter. If the UI does not clear the input, fall back to the dedicated
+      // submit button and fail explicitly if neither path submits the turn.
       log.info(`  📤 Submitting question...`);
       await sendProgress?.("Submitting question...", 3, 5);
-      await page.keyboard.press("Enter");
+      const input = page.locator(inputSelector).first();
+      await input.press("Enter");
 
-      // Small pause after submit
-      await randomDelay(1000, 1500);
+      let inputCleared = false;
+      for (let attempt = 0; attempt < 20; attempt++) {
+        inputCleared = (await input.inputValue().catch(() => "")) === "";
+        if (inputCleared) break;
+        await page.waitForTimeout(150);
+      }
+
+      if (!inputCleared) {
+        const submitButton = page.locator(joinAlt(Selectors.chat.submitButton)).first();
+        if (
+          (await submitButton.count()) === 0 ||
+          !(await submitButton.isVisible().catch(() => false)) ||
+          !(await submitButton.isEnabled().catch(() => false))
+        ) {
+          throw new Error("NotebookLM did not accept the question submission");
+        }
+        await submitButton.click();
+      }
+
+      await randomDelay(250, 500);
 
       // Wait for the response with streaming-stability detection (issue #43).
       // Timeout comes from the request-scoped configuration so concurrent
       // HTTP calls cannot overwrite one another's limits.
-      log.info(`  ⏳ Waiting for response (streaming-stability)...`);
-      await sendProgress?.("Waiting for NotebookLM response (streaming-stability)...", 3, 5);
+      log.info(`  ⏳ Waiting for the completed response for this turn...`);
+      await sendProgress?.("Waiting for NotebookLM final response...", 3, 5);
       const answer = await waitForStableAnswer(page, {
         question,
         timeoutMs: config.answerTimeoutMs,
@@ -804,11 +822,38 @@ export class BrowserSession {
         await this.init();
       }
       log.info(`🔄 [${this.sessionId}] Resetting chat history...`);
-      // Reload the page to clear chat history
-      await (this.page as Page).reload({ waitUntil: "domcontentloaded" });
-      await randomDelay(2000, 3000);
+      const page = this.page as Page;
 
-      // Wait for interface to be ready again
+      // Reloading does not clear NotebookLM's server-side conversation. Use
+      // the actual "Clear chat history" action exposed by the current UI.
+      const optionsButton = page.locator(joinAlt(Selectors.chat.optionsButton)).first();
+      await optionsButton.waitFor({ state: "visible", timeout: 10_000 });
+      await optionsButton.click();
+
+      const clearHistoryItem = page.locator(joinAlt(Selectors.chat.clearHistoryMenuItem)).first();
+      await clearHistoryItem.waitFor({ state: "visible", timeout: 5_000 });
+      await clearHistoryItem.click();
+
+      // Some NotebookLM builds ask for confirmation; others clear directly.
+      await page.waitForTimeout(300);
+      const dialog = page.locator('[role="dialog"]').last();
+      if ((await dialog.count()) > 0 && (await dialog.isVisible().catch(() => false))) {
+        const confirmButton = dialog
+          .locator(joinAlt(Selectors.chat.clearHistoryConfirmButton))
+          .last();
+        await confirmButton.waitFor({ state: "visible", timeout: 5_000 });
+        await confirmButton.click();
+      }
+
+      const clearDeadline = Date.now() + 15_000;
+      const answers = page.locator(Selectors.chat.answerContainer);
+      while (Date.now() < clearDeadline && (await answers.count()) > 0) {
+        await page.waitForTimeout(250);
+      }
+      if ((await answers.count()) > 0) {
+        throw new Error("NotebookLM did not clear the chat history");
+      }
+
       await this.waitForNotebookLMReady();
 
       // Reset message count

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -19,6 +19,7 @@ import { CONFIG } from "../config.js";
 import { log } from "../utils/logger.js";
 import type { SessionInfo } from "../types.js";
 import { randomBytes } from "crypto";
+import { normalizeNotebookUrl } from "../notebooklm/url.js";
 
 export class SessionManager {
   private authManager: AuthManager;
@@ -27,6 +28,7 @@ export class SessionManager {
   private maxSessions: number;
   private sessionTimeout: number;
   private cleanupInterval?: NodeJS.Timeout;
+  private sessionMutationTail: Promise<void> = Promise.resolve();
 
   constructor(authManager: AuthManager) {
     this.authManager = authManager;
@@ -68,14 +70,30 @@ export class SessionManager {
     notebookUrl?: string,
     overrideHeadless?: boolean
   ): Promise<BrowserSession> {
+    let release!: () => void;
+    const previous = this.sessionMutationTail;
+    this.sessionMutationTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await this.getOrCreateSessionUnlocked(sessionId, notebookUrl, overrideHeadless);
+    } finally {
+      release();
+    }
+  }
+
+  private async getOrCreateSessionUnlocked(
+    sessionId?: string,
+    notebookUrl?: string,
+    overrideHeadless?: boolean
+  ): Promise<BrowserSession> {
     // Determine target notebook URL
-    const targetUrl = (notebookUrl || CONFIG.notebookUrl || "").trim();
-    if (!targetUrl) {
+    const requestedUrl = (notebookUrl || CONFIG.notebookUrl || "").trim();
+    if (!requestedUrl) {
       throw new Error("Notebook URL is required to create a session");
     }
-    if (!targetUrl.startsWith("http")) {
-      throw new Error("Notebook URL must be an absolute URL");
-    }
+    const targetUrl = normalizeNotebookUrl(requestedUrl);
 
     // Generate ID if not provided
     if (!sessionId) {
@@ -86,17 +104,20 @@ export class SessionManager {
     // Check if browser visibility mode needs to change
     if (overrideHeadless !== undefined) {
       if (this.sharedContextManager.needsHeadlessModeChange(overrideHeadless)) {
-        log.warning(
-          `🔄 Browser visibility changed - closing all sessions to recreate browser context...`
-        );
+        if (this.sessions.size > 0) {
+          throw new Error(
+            "Browser visibility cannot change while sessions are active. " +
+              "Close active sessions first or start the server with the desired HEADLESS setting."
+          );
+        }
+        log.warning(`🔄 Browser visibility changed - recreating idle browser context...`);
         const currentMode = this.sharedContextManager.getCurrentHeadlessMode();
         log.info(
           `  Switching from ${currentMode ? "HEADLESS" : "VISIBLE"} to ${overrideHeadless ? "VISIBLE" : "HEADLESS"}`
         );
 
-        // Close all sessions (they all use the same context)
         await this.closeAllSessions();
-        log.success(`  ✅ All sessions closed, browser context will be recreated with new mode`);
+        log.success(`  ✅ Browser context will be recreated with new mode`);
       }
     }
 
@@ -284,14 +305,10 @@ export class SessionManager {
   }
 
   /**
-   * Close all sessions (used during shutdown)
+   * Close all sessions without disabling periodic cleanup. Used by runtime
+   * operations such as re-authentication and browser-mode changes.
    */
   async closeAllSessions(): Promise<void> {
-    if (this.cleanupInterval) {
-      clearInterval(this.cleanupInterval);
-      this.cleanupInterval = undefined;
-    }
-
     if (this.sessions.size === 0) {
       log.warning("🛑 Closing shared context (no active sessions)...");
       await this.sharedContextManager.closeContext();
@@ -315,6 +332,14 @@ export class SessionManager {
     await this.sharedContextManager.closeContext();
 
     log.success("✅ All sessions closed");
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = undefined;
+    }
+    await this.closeAllSessions();
   }
 
   /**

--- a/src/session/shared-context-manager.ts
+++ b/src/session/shared-context-manager.ts
@@ -14,7 +14,7 @@
 
 import type { BrowserContext } from "patchright";
 import { chromium } from "patchright";
-import { CONFIG } from "../config.js";
+import { CONFIG, getRuntimeConfig } from "../config.js";
 import { log } from "../utils/logger.js";
 import type { AuthManager } from "../auth/auth-manager.js";
 import {
@@ -127,6 +127,7 @@ export class SharedContextManager {
    * @param overrideHeadless Optional override for headless mode (true = show browser)
    */
   private async recreateContext(overrideHeadless?: boolean): Promise<void> {
+    const config = getRuntimeConfig();
     // Close old context if exists
     if (this.globalContext) {
       try {
@@ -149,7 +150,7 @@ export class SharedContextManager {
     }
 
     // Determine headless mode: use override if provided, otherwise use CONFIG
-    const shouldBeHeadless = overrideHeadless !== undefined ? !overrideHeadless : CONFIG.headless;
+    const shouldBeHeadless = overrideHeadless !== undefined ? !overrideHeadless : config.headless;
 
     if (overrideHeadless !== undefined) {
       log.info(`  Browser visibility override: ${overrideHeadless ? "VISIBLE" : "HEADLESS"}`);
@@ -159,7 +160,7 @@ export class SharedContextManager {
     // NOTE: userDataDir is passed as first parameter, NOT in options!
     const baseLaunchOptions = {
       headless: shouldBeHeadless,
-      viewport: CONFIG.viewport,
+      viewport: config.viewport,
       locale: "en-US",
       timezoneId: "Europe/Berlin",
       // ✅ CRITICAL FIX: Pass storageState directly at launch!
@@ -182,8 +183,8 @@ export class SharedContextManager {
     // (issue #13 macOS Tahoe Chrome crash, issue #19 Windows exit code 21).
     // We start with the user-preferred channel (default `chrome`) and, on a
     // recognised channel-failure, retry with bundled `chromium`.
-    const baseProfile = CONFIG.chromeProfileDir;
-    const strategy = CONFIG.profileStrategy;
+    const baseProfile = config.chromeProfileDir;
+    const strategy = config.profileStrategy;
     const preferred = getPreferredChannel();
     const tryLaunch = async (userDataDir: string) => {
       log.info("  🚀 Launching persistent Chrome context...");
@@ -478,8 +479,8 @@ export class SharedContextManager {
 
     // Calculate target headless mode
     // If override is specified, use it (!overrideHeadless because true = show browser = headless false)
-    // Otherwise, use CONFIG.headless (which may have been temporarily modified by browser_options)
-    const targetHeadless = overrideHeadless !== undefined ? !overrideHeadless : CONFIG.headless;
+    const targetHeadless =
+      overrideHeadless !== undefined ? !overrideHeadless : getRuntimeConfig().headless;
 
     // Compare with current mode
     const needsChange = this.currentHeadlessMode !== targetHeadless;

--- a/src/tools/definitions/ask-question.ts
+++ b/src/tools/definitions/ask-question.ts
@@ -144,7 +144,8 @@ export const askQuestionTool: Tool = {
         description:
           "Direct NotebookLM URL — overrides `notebook_id`. Use for ad-hoc " +
           "queries against notebooks not yet in your library. Format: " +
-          "`https://notebooklm.google.com/notebook/<uuid>`.",
+          "`https://notebook.google.com/notebook/<uuid>` (the legacy " +
+          "`notebooklm.google.com` host is also accepted).",
       },
       source_format: {
         type: "string",
@@ -152,8 +153,8 @@ export const askQuestionTool: Tool = {
         description:
           "How citations are returned alongside the answer:\n" +
           "  • `none` (default) — raw answer, no citation extraction (fastest)\n" +
-          "  • `footnotes` — answer plus a `Sources:` block, e.g. `[1] DocName — \"excerpt…\"`\n" +
-          "  • `inline` — `[N]` markers in the answer are replaced with `[N] (DocName: \"excerpt…\")`\n" +
+          '  • `footnotes` — answer plus a `Sources:` block, e.g. `[1] DocName — "excerpt…"`\n' +
+          '  • `inline` — `[N]` markers in the answer are replaced with `[N] (DocName: "excerpt…")`\n' +
           "  • `json` — answer text untouched; structured `sources` array on the response\n\n" +
           "Use `none` for snappy chat. Use `json` when downstream code needs to " +
           "process citations programmatically. Use `footnotes`/`inline` when " +
@@ -182,6 +183,10 @@ export const askQuestionTool: Tool = {
           timeout_ms: {
             type: "number",
             description: "Browser operation timeout in milliseconds (default: 30000)",
+          },
+          answer_timeout_ms: {
+            type: "number",
+            description: "Maximum wait for a NotebookLM answer in milliseconds (default: 600000)",
           },
           stealth: {
             type: "object",

--- a/src/tools/definitions/notebook-management.ts
+++ b/src/tools/definitions/notebook-management.ts
@@ -34,7 +34,8 @@ export const notebookManagementTools: Tool[] = [
           type: "string",
           description:
             "NotebookLM share URL. Format: " +
-            "`https://notebooklm.google.com/notebook/<uuid>` (with optional " +
+            "`https://notebook.google.com/notebook/<uuid>` (the legacy " +
+            "`notebooklm.google.com` host is also accepted; optional " +
             "`?authuser=N` suffix).",
         },
         name: {
@@ -126,9 +127,9 @@ export const notebookManagementTools: Tool[] = [
       "caller omits `notebook_id` / `notebook_url`.\n\n" +
       "When to call:\n" +
       "  • The user explicitly switches context (e.g. \"Let's work on " +
-      "React now\")\n" +
+      'React now")\n' +
       "  • Task obviously needs a different notebook than the current one — " +
-      "announce the switch (\"Switching to the React notebook…\") before " +
+      'announce the switch ("Switching to the React notebook…") before ' +
       "calling.\n" +
       "  • If the right notebook is ambiguous, ask the user first instead " +
       "of guessing.",
@@ -235,8 +236,8 @@ export const notebookManagementTools: Tool[] = [
       "Search the library by free-text query — matches against `name`, " +
       "`description`, `topics`, and `tags`. Returns notebook objects with " +
       "their `id` so you can chain into `select_notebook` etc.\n\n" +
-      "Use this when the user references a notebook by topic (\"the React " +
-      "one\") instead of by exact name. If multiple notebooks match, " +
+      'Use this when the user references a notebook by topic ("the React ' +
+      'one") instead of by exact name. If multiple notebooks match, ' +
       "propose the top 1–2 and let the user choose.",
     inputSchema: {
       type: "object",
@@ -260,7 +261,7 @@ export const notebookManagementTools: Tool[] = [
       "Aggregate statistics about the local notebook library: " +
       "`total_notebooks`, `active_notebook` (id), `most_used_notebook`, " +
       "`total_queries`, `last_modified`. Useful as a quick health check or " +
-      "when the user asks \"what notebooks do I have?\".",
+      'when the user asks "what notebooks do I have?".',
     inputSchema: {
       type: "object",
       properties: {},

--- a/src/tools/definitions/sources.ts
+++ b/src/tools/definitions/sources.ts
@@ -28,7 +28,8 @@ const sharedNotebookTargeting = {
     description:
       "Direct NotebookLM URL — overrides `notebook_id`. Use for ad-hoc " +
       "notebooks not yet in your library. Format: " +
-      "`https://notebooklm.google.com/notebook/<uuid>`.",
+      "`https://notebook.google.com/notebook/<uuid>` (the legacy " +
+      "`notebooklm.google.com` host is also accepted).",
   },
 };
 
@@ -46,7 +47,7 @@ export const addSourceTool: Tool = {
     "subsequent `ask_question` calls then have the new source in context. " +
     "Free notebooks cap at 50 sources.\n\n" +
     "Known quirk: pasted-text uploads occasionally redirect to a freshly " +
-    "created \"Untitled notebook\" on Google's side. The tool detects this " +
+    'created "Untitled notebook" on Google\'s side. The tool detects this ' +
     "and returns a clear error so you can re-try against the correct URL.",
   inputSchema: {
     type: "object",
@@ -94,10 +95,10 @@ export const generateAudioTool: Tool = {
   description:
     "Trigger podcast-style Audio Overview generation for a notebook.\n\n" +
     "**Async by default** — returns immediately with one of:\n" +
-    "  • `status: \"started\"` — generation just kicked off\n" +
-    "  • `status: \"in_progress\"` — a generation was already running; " +
+    '  • `status: "started"` — generation just kicked off\n' +
+    '  • `status: "in_progress"` — a generation was already running; ' +
     "this call attached to it\n" +
-    "  • `status: \"ready\"` (with `alreadyExisted: true`) — an Audio " +
+    '  • `status: "ready"` (with `alreadyExisted: true`) — an Audio ' +
     "Overview already existed; nothing was triggered\n\n" +
     "Generation typically takes 2–10 minutes. **Workflow:**\n" +
     "  1. `generate_audio` → returns immediately\n" +
@@ -113,9 +114,9 @@ export const generateAudioTool: Tool = {
       custom_prompt: {
         type: "string",
         description:
-          "Optional focus prompt for the Audio Overview, e.g. \"Focus on the " +
-          "API authentication flow and skip pricing\". Passed into the " +
-          "NotebookLM \"Customize\" sub-dialog before generation starts.",
+          'Optional focus prompt for the Audio Overview, e.g. "Focus on the ' +
+          'API authentication flow and skip pricing". Passed into the ' +
+          'NotebookLM "Customize" sub-dialog before generation starts.',
       },
       wait_for_completion: {
         type: "boolean",
@@ -178,7 +179,7 @@ export const downloadAudioTool: Tool = {
   name: "download_audio",
   description:
     "Save the completed Audio Overview to disk as a `.m4a` file. **Pre-" +
-    "condition:** `get_audio_status` must report `status: \"ready\"`. " +
+    'condition:** `get_audio_status` must report `status: "ready"`. ' +
     "Calling this before generation completes returns an error message " +
     "explaining what to do.\n\n" +
     "The file lands in `destination_dir` with NotebookLM's suggested " +

--- a/src/tools/definitions/system.ts
+++ b/src/tools/definitions/system.ts
@@ -35,7 +35,8 @@ export const systemTools: Tool[] = [
     description:
       "Open a browser window for first-time Google login. Returns immediately " +
       "after spawning the browser; the user has up to 10 minutes to complete " +
-      "sign-in, then cookies are persisted for future runs.\n\n" +
+      "sign-in, then cookies are persisted for future runs. Existing profile " +
+      "data is preserved; use `re_auth` when a clean login is required.\n\n" +
       "When to use:\n" +
       "  • `get_health` reports `authenticated=false` for the first time\n" +
       "  • Auto-login credentials are not configured\n" +

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -15,7 +15,7 @@ import type {
 } from "../library/types.js";
 import type { AddSourceResult } from "../notebooklm/sources.js";
 import type { AudioGenerationResult, DownloadAudioResult } from "../notebooklm/audio.js";
-import { CONFIG, applyBrowserOptions, type BrowserOptions } from "../config.js";
+import { CONFIG, applyBrowserOptions, withRuntimeConfig, type BrowserOptions } from "../config.js";
 import { log } from "../utils/logger.js";
 import type { AskQuestionResult, ToolResult, ProgressCallback } from "../types.js";
 import { RateLimitError } from "../errors.js";
@@ -116,23 +116,21 @@ export class ToolHandlers {
       // Progress: Getting or creating session
       await sendProgress?.("Getting or creating browser session...", 1, 5);
 
-      // Apply browser options temporarily
-      const originalConfig = { ...CONFIG };
+      // Keep browser overrides scoped to this asynchronous call. This is
+      // concurrency-safe under Streamable HTTP.
       const effectiveConfig = applyBrowserOptions(browser_options, show_browser);
-      Object.assign(CONFIG, effectiveConfig);
 
-      // Calculate overrideHeadless parameter for session manager
-      // show_browser takes precedence over browser_options.headless
+      // Advanced browser_options take precedence over the legacy shorthand.
       let overrideHeadless: boolean | undefined = undefined;
-      if (show_browser !== undefined) {
-        overrideHeadless = show_browser;
-      } else if (browser_options?.show !== undefined) {
+      if (browser_options?.show !== undefined) {
         overrideHeadless = browser_options.show;
       } else if (browser_options?.headless !== undefined) {
         overrideHeadless = !browser_options.headless;
+      } else if (show_browser !== undefined) {
+        overrideHeadless = show_browser;
       }
 
-      try {
+      return await withRuntimeConfig(effectiveConfig, async () => {
         // Get or create session (with headless override to handle mode changes)
         const session = await this.sessionManager.getOrCreateSession(
           session_id,
@@ -144,11 +142,13 @@ export class ToolHandlers {
         await sendProgress?.("Asking question to NotebookLM...", 2, 5);
 
         // Ask the question (pass progress callback)
-        const rawAnswer = await session.ask(question, sendProgress);
-
-        // Extract citations from the same page session before any other call
-        // disturbs the source panel (issue #20).
-        const citationResult = await session.extractCitations(rawAnswer, source_format);
+        // Asking and citation extraction share one per-session lock so a
+        // concurrent follow-up cannot disturb the citation panel.
+        const citationResult = await session.askAndExtractCitations(
+          question,
+          source_format,
+          sendProgress
+        );
         const baseAnswer = citationResult.formattedAnswer;
 
         const trimmed = baseAnswer.trimEnd();
@@ -184,10 +184,7 @@ export class ToolHandlers {
           success: true,
           data: result,
         };
-      } finally {
-        // Restore original CONFIG
-        Object.assign(CONFIG, originalConfig);
-      }
+      });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -462,58 +459,54 @@ export class ToolHandlers {
 
     const startTime = Date.now();
 
-    // Apply browser options temporarily
-    const originalConfig = { ...CONFIG };
     const effectiveConfig = applyBrowserOptions(browser_options, show_browser);
-    Object.assign(CONFIG, effectiveConfig);
 
-    try {
-      // Progress: Starting
-      await sendProgress?.("Preparing authentication browser...", 1, 10);
+    return await withRuntimeConfig(effectiveConfig, async () => {
+      try {
+        // Progress: Starting
+        await sendProgress?.("Preparing authentication browser...", 1, 10);
 
-      log.info(`  🌐 Opening browser for interactive login...`);
+        log.info(`  🌐 Opening browser for interactive login...`);
 
-      // Progress: Opening browser
-      await sendProgress?.("Opening browser window...", 2, 10);
+        // Progress: Opening browser
+        await sendProgress?.("Opening browser window...", 2, 10);
 
-      // Perform setup with progress updates (uses CONFIG internally)
-      const success = await this.authManager.performSetup(sendProgress);
+        // Perform setup with progress updates (uses CONFIG internally)
+        const success = await this.authManager.performSetup(sendProgress);
 
-      const durationSeconds = (Date.now() - startTime) / 1000;
+        const durationSeconds = (Date.now() - startTime) / 1000;
 
-      if (success) {
-        // Progress: Complete
-        await sendProgress?.("Authentication saved successfully!", 10, 10);
+        if (success) {
+          // Progress: Complete
+          await sendProgress?.("Authentication saved successfully!", 10, 10);
 
-        log.success(`✅ [TOOL] setup_auth completed (${durationSeconds.toFixed(1)}s)`);
-        return {
-          success: true,
-          data: {
-            status: "authenticated",
-            message: "Successfully authenticated and saved browser state",
-            authenticated: true,
-            duration_seconds: durationSeconds,
-          },
-        };
-      } else {
-        log.error(`❌ [TOOL] setup_auth failed (${durationSeconds.toFixed(1)}s)`);
+          log.success(`✅ [TOOL] setup_auth completed (${durationSeconds.toFixed(1)}s)`);
+          return {
+            success: true,
+            data: {
+              status: "authenticated",
+              message: "Successfully authenticated and saved browser state",
+              authenticated: true,
+              duration_seconds: durationSeconds,
+            },
+          };
+        } else {
+          log.error(`❌ [TOOL] setup_auth failed (${durationSeconds.toFixed(1)}s)`);
+          return {
+            success: false,
+            error: "Authentication failed or was cancelled",
+          };
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const durationSeconds = (Date.now() - startTime) / 1000;
+        log.error(`❌ [TOOL] setup_auth failed: ${errorMessage} (${durationSeconds.toFixed(1)}s)`);
         return {
           success: false,
-          error: "Authentication failed or was cancelled",
+          error: errorMessage,
         };
       }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      const durationSeconds = (Date.now() - startTime) / 1000;
-      log.error(`❌ [TOOL] setup_auth failed: ${errorMessage} (${durationSeconds.toFixed(1)}s)`);
-      return {
-        success: false,
-        error: errorMessage,
-      };
-    } finally {
-      // Restore original CONFIG
-      Object.assign(CONFIG, originalConfig);
-    }
+    });
   }
 
   /**
@@ -550,63 +543,59 @@ export class ToolHandlers {
 
     const startTime = Date.now();
 
-    // Apply browser options temporarily
-    const originalConfig = { ...CONFIG };
     const effectiveConfig = applyBrowserOptions(browser_options, show_browser);
-    Object.assign(CONFIG, effectiveConfig);
 
-    try {
-      // 1. Close all active sessions
-      await sendProgress?.("Closing all active sessions...", 1, 12);
-      log.info("  🛑 Closing all sessions...");
-      await this.sessionManager.closeAllSessions();
-      log.success("  ✅ All sessions closed");
+    return await withRuntimeConfig(effectiveConfig, async () => {
+      try {
+        // 1. Close all active sessions
+        await sendProgress?.("Closing all active sessions...", 1, 12);
+        log.info("  🛑 Closing all sessions...");
+        await this.sessionManager.closeAllSessions();
+        log.success("  ✅ All sessions closed");
 
-      // 2. Clear all auth data
-      await sendProgress?.("Clearing authentication data...", 2, 12);
-      log.info("  🗑️  Clearing all auth data...");
-      await this.authManager.clearAllAuthData();
-      log.success("  ✅ Auth data cleared");
+        // 2. Clear all auth data
+        await sendProgress?.("Clearing authentication data...", 2, 12);
+        log.info("  🗑️  Clearing all auth data...");
+        await this.authManager.clearAllAuthData();
+        log.success("  ✅ Auth data cleared");
 
-      // 3. Perform fresh setup
-      await sendProgress?.("Starting fresh authentication...", 3, 12);
-      log.info("  🌐 Starting fresh authentication setup...");
-      const success = await this.authManager.performSetup(sendProgress);
+        // 3. Perform fresh setup
+        await sendProgress?.("Starting fresh authentication...", 3, 12);
+        log.info("  🌐 Starting fresh authentication setup...");
+        const success = await this.authManager.performSetup(sendProgress);
 
-      const durationSeconds = (Date.now() - startTime) / 1000;
+        const durationSeconds = (Date.now() - startTime) / 1000;
 
-      if (success) {
-        await sendProgress?.("Re-authentication complete!", 12, 12);
-        log.success(`✅ [TOOL] re_auth completed (${durationSeconds.toFixed(1)}s)`);
-        return {
-          success: true,
-          data: {
-            status: "authenticated",
-            message:
-              "Successfully re-authenticated with new account. All previous sessions have been closed.",
-            authenticated: true,
-            duration_seconds: durationSeconds,
-          },
-        };
-      } else {
-        log.error(`❌ [TOOL] re_auth failed (${durationSeconds.toFixed(1)}s)`);
+        if (success) {
+          await sendProgress?.("Re-authentication complete!", 12, 12);
+          log.success(`✅ [TOOL] re_auth completed (${durationSeconds.toFixed(1)}s)`);
+          return {
+            success: true,
+            data: {
+              status: "authenticated",
+              message:
+                "Successfully re-authenticated with new account. All previous sessions have been closed.",
+              authenticated: true,
+              duration_seconds: durationSeconds,
+            },
+          };
+        } else {
+          log.error(`❌ [TOOL] re_auth failed (${durationSeconds.toFixed(1)}s)`);
+          return {
+            success: false,
+            error: "Re-authentication failed or was cancelled",
+          };
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const durationSeconds = (Date.now() - startTime) / 1000;
+        log.error(`❌ [TOOL] re_auth failed: ${errorMessage} (${durationSeconds.toFixed(1)}s)`);
         return {
           success: false,
-          error: "Re-authentication failed or was cancelled",
+          error: errorMessage,
         };
       }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      const durationSeconds = (Date.now() - startTime) / 1000;
-      log.error(`❌ [TOOL] re_auth failed: ${errorMessage} (${durationSeconds.toFixed(1)}s)`);
-      return {
-        success: false,
-        error: errorMessage,
-      };
-    } finally {
-      // Restore original CONFIG
-      Object.assign(CONFIG, originalConfig);
-    }
+    });
   }
 
   /**
@@ -968,32 +957,28 @@ export class ToolHandlers {
     show_browser?: boolean;
   }): Promise<ToolResult<{ result: AddSourceResult }>> {
     log.info(`🔧 [TOOL] add_source called (type=${args.type})`);
-    const originalConfig = { ...CONFIG };
-    if (args.show_browser !== undefined) {
-      const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
-      Object.assign(CONFIG, effectiveConfig);
-    }
+    const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
     const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
-    try {
-      const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
-      const session = await this.sessionManager.getOrCreateSession(
-        args.session_id,
-        url,
-        overrideHeadless
-      );
-      const result = await session.addSource({
-        type: args.type,
-        content: args.content,
-        title: args.title,
-      });
-      return { success: result.success, data: { result } };
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      log.error(`❌ [TOOL] add_source failed: ${msg}`);
-      return { success: false, error: msg };
-    } finally {
-      Object.assign(CONFIG, originalConfig);
-    }
+    return await withRuntimeConfig(effectiveConfig, async () => {
+      try {
+        const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
+        const session = await this.sessionManager.getOrCreateSession(
+          args.session_id,
+          url,
+          overrideHeadless
+        );
+        const result = await session.addSource({
+          type: args.type,
+          content: args.content,
+          title: args.title,
+        });
+        return { success: result.success, data: { result } };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        log.error(`❌ [TOOL] add_source failed: ${msg}`);
+        return { success: false, error: msg };
+      }
+    });
   }
 
   /**
@@ -1009,37 +994,34 @@ export class ToolHandlers {
     show_browser?: boolean;
   }): Promise<ToolResult<{ result: AudioGenerationResult }>> {
     log.info(`🔧 [TOOL] generate_audio called`);
-    const originalConfig = { ...CONFIG };
-    if (args.show_browser !== undefined) {
-      Object.assign(CONFIG, applyBrowserOptions(undefined, args.show_browser));
-    }
+    const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
     const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
-    try {
-      const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
-      const session = await this.sessionManager.getOrCreateSession(
-        args.session_id,
-        url,
-        overrideHeadless
-      );
-      const result = await session.generateAudio({
-        customPrompt: args.custom_prompt,
-        timeoutMs: args.timeout_ms,
-        waitForCompletion: args.wait_for_completion ?? false,
-      });
-      // `started` and `in_progress` count as success — the generation is on
-      // its way; the caller polls `get_audio_status` for completion.
-      const ok =
-        result.status === "ready" ||
-        result.status === "started" ||
-        result.status === "in_progress";
-      return { success: ok, data: { result } };
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      log.error(`❌ [TOOL] generate_audio failed: ${msg}`);
-      return { success: false, error: msg };
-    } finally {
-      Object.assign(CONFIG, originalConfig);
-    }
+    return await withRuntimeConfig(effectiveConfig, async () => {
+      try {
+        const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
+        const session = await this.sessionManager.getOrCreateSession(
+          args.session_id,
+          url,
+          overrideHeadless
+        );
+        const result = await session.generateAudio({
+          customPrompt: args.custom_prompt,
+          timeoutMs: args.timeout_ms,
+          waitForCompletion: args.wait_for_completion ?? false,
+        });
+        // `started` and `in_progress` count as success — the generation is on
+        // its way; the caller polls `get_audio_status` for completion.
+        const ok =
+          result.status === "ready" ||
+          result.status === "started" ||
+          result.status === "in_progress";
+        return { success: ok, data: { result } };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        log.error(`❌ [TOOL] generate_audio failed: ${msg}`);
+        return { success: false, error: msg };
+      }
+    });
   }
 
   /**
@@ -1052,27 +1034,24 @@ export class ToolHandlers {
     show_browser?: boolean;
   }): Promise<ToolResult<{ result: AudioGenerationResult }>> {
     log.info(`🔧 [TOOL] get_audio_status called`);
-    const originalConfig = { ...CONFIG };
-    if (args.show_browser !== undefined) {
-      Object.assign(CONFIG, applyBrowserOptions(undefined, args.show_browser));
-    }
+    const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
     const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
-    try {
-      const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
-      const session = await this.sessionManager.getOrCreateSession(
-        args.session_id,
-        url,
-        overrideHeadless
-      );
-      const result = await session.getAudioStatus();
-      return { success: true, data: { result } };
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      log.error(`❌ [TOOL] get_audio_status failed: ${msg}`);
-      return { success: false, error: msg };
-    } finally {
-      Object.assign(CONFIG, originalConfig);
-    }
+    return await withRuntimeConfig(effectiveConfig, async () => {
+      try {
+        const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
+        const session = await this.sessionManager.getOrCreateSession(
+          args.session_id,
+          url,
+          overrideHeadless
+        );
+        const result = await session.getAudioStatus();
+        return { success: true, data: { result } };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        log.error(`❌ [TOOL] get_audio_status failed: ${msg}`);
+        return { success: false, error: msg };
+      }
+    });
   }
 
   /**
@@ -1086,27 +1065,24 @@ export class ToolHandlers {
     show_browser?: boolean;
   }): Promise<ToolResult<{ result: DownloadAudioResult }>> {
     log.info(`🔧 [TOOL] download_audio called`);
-    const originalConfig = { ...CONFIG };
-    if (args.show_browser !== undefined) {
-      Object.assign(CONFIG, applyBrowserOptions(undefined, args.show_browser));
-    }
+    const effectiveConfig = applyBrowserOptions(undefined, args.show_browser);
     const overrideHeadless = args.show_browser === undefined ? undefined : args.show_browser;
-    try {
-      const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
-      const session = await this.sessionManager.getOrCreateSession(
-        args.session_id,
-        url,
-        overrideHeadless
-      );
-      const result = await session.downloadAudio(args.destination_dir);
-      return { success: result.success, data: { result } };
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      log.error(`❌ [TOOL] download_audio failed: ${msg}`);
-      return { success: false, error: msg };
-    } finally {
-      Object.assign(CONFIG, originalConfig);
-    }
+    return await withRuntimeConfig(effectiveConfig, async () => {
+      try {
+        const url = await this.resolveNotebookUrl(args.notebook_id, args.notebook_url);
+        const session = await this.sessionManager.getOrCreateSession(
+          args.session_id,
+          url,
+          overrideHeadless
+        );
+        const result = await session.downloadAudio(args.destination_dir);
+        return { success: result.success, data: { result } };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        log.error(`❌ [TOOL] download_audio failed: ${msg}`);
+        return { success: false, error: msg };
+      }
+    });
   }
 
   /**
@@ -1114,7 +1090,7 @@ export class ToolHandlers {
    */
   async cleanup(): Promise<void> {
     log.info(`🧹 Cleaning up tool handlers...`);
-    await this.sessionManager.closeAllSessions();
+    await this.sessionManager.shutdown();
     log.success(`✅ Tool handlers cleanup complete`);
   }
 }

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -15,11 +15,11 @@
 
 import {
   createServer,
-  IncomingMessage,
   type Server as HttpServer,
-  ServerResponse,
+  type IncomingMessage,
+  type ServerResponse,
 } from "node:http";
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import type { Server as McpServer } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
@@ -28,6 +28,10 @@ import { log } from "../utils/logger.js";
 export interface HttpTransportOptions {
   port: number;
   host?: string;
+  authToken?: string;
+  allowedOrigins?: readonly string[];
+  allowedHosts?: readonly string[];
+  maxBodyBytes?: number;
   /** Connect callback invoked once per new session — wires the McpServer to the transport. */
   connect: (transport: StreamableHTTPServerTransport) => Promise<void>;
 }
@@ -44,13 +48,29 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
 
   const server = createServer((req, res) => {
     void handleRequest(req, res, transports, opts).catch((err) => {
-      log.error(`❌ [HTTP] Unhandled request error: ${err}`);
+      if (err instanceof HttpRequestError) {
+        log.warning(`⚠️  [HTTP] Rejected request: ${err.message}`);
+      } else {
+        log.error(`❌ [HTTP] Unhandled request error: ${err}`);
+      }
       if (!res.headersSent) {
-        res.writeHead(500, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "internal server error" }));
+        const status = err instanceof HttpRequestError ? err.status : 500;
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: status === 500 ? "internal server error" : String(err.message),
+          })
+        );
       }
     });
   });
+  server.requestTimeout = 30_000;
+  server.headersTimeout = 15_000;
+
+  const bindHost = opts.host ?? "127.0.0.1";
+  if (!isLoopbackHost(bindHost) && !opts.authToken) {
+    throw new Error("HTTP transport bound outside localhost requires NOTEBOOKLM_HTTP_AUTH_TOKEN");
+  }
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -98,7 +118,20 @@ async function handleRequest(
   transports: Map<string, StreamableHTTPServerTransport>,
   opts: HttpTransportOptions
 ): Promise<void> {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  applyHttpSecurity(req, res, opts);
+  const url = new URL(req.url ?? "/", "http://localhost");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      Allow: "POST, GET, DELETE, OPTIONS",
+      "Access-Control-Allow-Methods": "POST, GET, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Authorization, Content-Type, Accept, Mcp-Session-Id, MCP-Protocol-Version",
+      "Access-Control-Expose-Headers": "Mcp-Session-Id",
+    });
+    res.end();
+    return;
+  }
 
   if (url.pathname === "/healthz" && req.method === "GET") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -132,7 +165,7 @@ async function handleRequest(
     return;
   }
 
-  const body = await readJsonBody(req);
+  const body = await readJsonBody(req, opts.maxBodyBytes ?? 1024 * 1024);
 
   // Re-use existing session, or initialise a new one when the client says so.
   let transport = sessionId ? transports.get(sessionId) : undefined;
@@ -162,10 +195,16 @@ async function handleRequest(
   await transport.handleRequest(req, res, body);
 }
 
-async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+async function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
   const chunks: Buffer[] = [];
+  let receivedBytes = 0;
   for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    receivedBytes += buffer.length;
+    if (receivedBytes > maxBytes) {
+      throw new HttpRequestError(413, `request body exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(buffer);
   }
   if (chunks.length === 0) return undefined;
   const raw = Buffer.concat(chunks).toString("utf8");
@@ -173,11 +212,89 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   try {
     return JSON.parse(raw);
   } catch {
-    throw new Error("Invalid JSON request body");
+    throw new HttpRequestError(400, "invalid JSON request body");
   }
 }
 
 function headerString(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) return value[0];
   return value;
+}
+
+class HttpRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "HttpRequestError";
+  }
+}
+
+function applyHttpSecurity(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: HttpTransportOptions
+): void {
+  const hostHeader = headerString(req.headers.host);
+  const hostname = hostHeader ? stripPort(hostHeader).toLowerCase() : "";
+  const bindHost = (opts.host ?? "127.0.0.1").toLowerCase();
+  const allowedHosts = new Set(
+    (opts.allowedHosts ?? [bindHost, "localhost", "127.0.0.1", "::1"]).map((value) =>
+      value.toLowerCase()
+    )
+  );
+  if (!hostname || (!allowedHosts.has(hostname) && !isLoopbackHost(hostname))) {
+    throw new HttpRequestError(403, "host is not allowed");
+  }
+
+  const origin = headerString(req.headers.origin);
+  if (origin) {
+    let originUrl: URL;
+    try {
+      originUrl = new URL(origin);
+    } catch {
+      throw new HttpRequestError(403, "origin is invalid");
+    }
+    const explicitlyAllowed = new Set(opts.allowedOrigins ?? []).has(originUrl.origin);
+    if (!explicitlyAllowed && !isLoopbackHost(originUrl.hostname)) {
+      throw new HttpRequestError(403, "origin is not allowed");
+    }
+    res.setHeader("Access-Control-Allow-Origin", originUrl.origin);
+    res.setHeader("Vary", "Origin");
+  }
+
+  if (opts.authToken && req.method !== "OPTIONS") {
+    const authorization = headerString(req.headers.authorization);
+    const supplied = authorization?.startsWith("Bearer ")
+      ? authorization.slice("Bearer ".length)
+      : "";
+    if (!safeTokenEquals(supplied, opts.authToken)) {
+      res.setHeader("WWW-Authenticate", "Bearer");
+      throw new HttpRequestError(401, "missing or invalid bearer token");
+    }
+  }
+}
+
+function safeTokenEquals(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    leftBuffer.length > 0 &&
+    timingSafeEqual(leftBuffer, rightBuffer)
+  );
+}
+
+function stripPort(host: string): string {
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    return end >= 0 ? host.slice(1, end) : host;
+  }
+  return host.replace(/:\d+$/, "");
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.replace(/^\[|\]$/g, "").toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
 }

--- a/src/utils/settings-manager.ts
+++ b/src/utils/settings-manager.ts
@@ -11,6 +11,7 @@ import path from "path";
 import { CONFIG } from "../config.js";
 import { log } from "./logger.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 
 export type ProfileName = "minimal" | "standard" | "full";
 
@@ -24,6 +25,12 @@ const DEFAULT_SETTINGS: Settings = {
   profile: "full",
   disabledTools: [],
 };
+
+const settingsSchema = z.object({
+  profile: z.enum(["minimal", "standard", "full"]).default("full"),
+  disabledTools: z.array(z.string()).default([]),
+  customSettings: z.record(z.unknown()).optional(),
+});
 
 function isProfileName(value: string | undefined): value is ProfileName {
   return value === "minimal" || value === "standard" || value === "full";
@@ -76,7 +83,7 @@ export class SettingsManager {
         // Synchronous read keeps the constructor simple — settings are tiny
         // and we need them before any tool dispatch can happen.
         const data = readFileSync(this.settingsPath, "utf-8");
-        return { ...DEFAULT_SETTINGS, ...JSON.parse(data) };
+        return settingsSchema.parse({ ...DEFAULT_SETTINGS, ...JSON.parse(data) });
       }
     } catch (error) {
       log.warning(`⚠️  Failed to load settings: ${error}. Using defaults.`);
@@ -88,10 +95,19 @@ export class SettingsManager {
    * Save current settings to file
    */
   async saveSettings(newSettings: Partial<Settings>): Promise<void> {
-    this.settings = { ...this.settings, ...newSettings };
+    const previousSettings = this.settings;
+    const nextSettings = settingsSchema.parse({ ...this.settings, ...newSettings });
+    const temporaryPath = `${this.settingsPath}.${process.pid}.tmp`;
     try {
-      await fs.writeFile(this.settingsPath, JSON.stringify(this.settings, null, 2), "utf-8");
+      await fs.writeFile(temporaryPath, JSON.stringify(nextSettings, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+      await fs.rename(temporaryPath, this.settingsPath);
+      this.settings = nextSettings;
     } catch (error) {
+      this.settings = previousSettings;
+      await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
       throw new Error(`Failed to save settings: ${error}`, { cause: error });
     }
   }

--- a/src/utils/stealth-utils.ts
+++ b/src/utils/stealth-utils.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Page } from "patchright";
-import { CONFIG } from "../config.js";
+import { getRuntimeConfig } from "../config.js";
 
 // ============================================================================
 // Helper Functions
@@ -70,10 +70,11 @@ export function gaussian(mean: number, stdDev: number): number {
  * @param maxMs Maximum delay in milliseconds (default: from CONFIG)
  */
 export async function randomDelay(minMs?: number, maxMs?: number): Promise<void> {
-  minMs = minMs ?? CONFIG.minDelayMs;
-  maxMs = maxMs ?? CONFIG.maxDelayMs;
+  const config = getRuntimeConfig();
+  minMs = minMs ?? config.minDelayMs;
+  maxMs = maxMs ?? config.maxDelayMs;
 
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthRandomDelays) {
+  if (!config.stealthEnabled || !config.stealthRandomDelays) {
     // Fixed delay (average)
     const target = minMs === maxMs ? minMs : (minMs + maxMs) / 2;
     if (target > 0) {
@@ -120,13 +121,14 @@ export async function humanType(
     withTypos?: boolean;
   } = {}
 ): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthHumanTyping) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthHumanTyping) {
     // Fast typing without stealth
     await page.fill(selector, text);
     return;
   }
 
-  const wpm = options.wpm ?? randomInt(CONFIG.typingWpmMin, CONFIG.typingWpmMax);
+  const wpm = options.wpm ?? randomInt(config.typingWpmMin, config.typingWpmMax);
   const withTypos = options.withTypos ?? true;
 
   // Calculate average delay per character (in ms)
@@ -144,32 +146,26 @@ export async function humanType(
   await randomDelay(20, 60);
 
   // Type each character
-  let currentText = "";
-  let i = 0;
-
-  while (i < text.length) {
+  for (let i = 0; i < text.length; i++) {
     const char = text[i];
 
     // Simulate very rare typo (0.3% chance) and shorter correction
     if (withTypos && Math.random() < 0.003 && i > 0) {
       // Type wrong character
       const wrongChar = randomChar();
-      currentText += wrongChar;
-      await page.fill(selector, currentText);
+      await page.keyboard.insertText(wrongChar);
 
       // Shorter notice window for faster typing
       const noticeDelay = randomFloat(avgDelayMs * 0.6, avgDelayMs * 1.1);
       await sleep(noticeDelay);
 
       // Backspace
-      currentText = currentText.slice(0, -1);
-      await page.fill(selector, currentText);
+      await page.keyboard.press("Backspace");
       await randomDelay(20, 60);
     }
 
     // Type correct character
-    currentText += char;
-    await page.fill(selector, currentText);
+    await page.keyboard.insertText(char);
 
     // Variable delay between characters – tuned for faster but still human-like typing
     let delay: number;
@@ -186,7 +182,6 @@ export async function humanType(
     }
 
     await sleep(delay);
-    i++;
   }
 
   // Small delay after finishing typing
@@ -212,11 +207,12 @@ export async function randomMouseMovement(
   targetY?: number,
   steps?: number
 ): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthMouseMovements) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthMouseMovements) {
     return;
   }
 
-  const viewport = page.viewportSize() || CONFIG.viewport;
+  const viewport = page.viewportSize() || config.viewport;
 
   targetX = targetX ?? randomInt(100, viewport.width - 100);
   targetY = targetY ?? randomInt(100, viewport.height - 100);
@@ -269,7 +265,8 @@ export async function realisticClick(
   selector: string,
   withMouseMovement: boolean = true
 ): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthMouseMovements) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthMouseMovements) {
     await page.click(selector);
     return;
   }
@@ -325,7 +322,8 @@ export async function smoothScroll(
     amount = -amount;
   }
 
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthMouseMovements) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthMouseMovements) {
     await page.evaluate((scrollAmount) => {
       window.scrollBy({ top: scrollAmount, behavior: "auto" });
     }, amount);
@@ -359,7 +357,8 @@ export async function smoothScroll(
  * @param wpm Reading speed in words per minute (default: random 200-250)
  */
 export async function readingPause(textLength: number, wpm?: number): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthRandomDelays) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthRandomDelays) {
     return;
   }
 
@@ -391,11 +390,12 @@ export async function readingPause(textLength: number, wpm?: number): Promise<vo
  * @param iterations Number of small movements (default: 3)
  */
 export async function randomMouseJitter(page: Page, iterations: number = 3): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthMouseMovements) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthMouseMovements) {
     return;
   }
 
-  const viewport = page.viewportSize() || CONFIG.viewport;
+  const viewport = page.viewportSize() || config.viewport;
 
   for (let i = 0; i < iterations; i++) {
     const targetX = randomInt(0, viewport.width);
@@ -416,7 +416,8 @@ export async function randomMouseJitter(page: Page, iterations: number = 3): Pro
  * @param selector CSS selector of element to hover
  */
 export async function hoverElement(page: Page, selector: string): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthMouseMovements) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthMouseMovements) {
     await page.hover(selector);
     return;
   }
@@ -447,7 +448,8 @@ export async function hoverElement(page: Page, selector: string): Promise<void> 
  * @param page Playwright page instance
  */
 export async function simulateReadingPage(page: Page): Promise<void> {
-  if (!CONFIG.stealthEnabled || !CONFIG.stealthRandomDelays) {
+  const config = getRuntimeConfig();
+  if (!config.stealthEnabled || !config.stealthRandomDelays) {
     return;
   }
 

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findCompletedTurnAnswer,
+  normalizeChatText,
+  sanitizeAnswer,
+  type ChatMessageSnapshot,
+} from "../src/notebooklm/chat.js";
+
+test("normalizes rendered whitespace before correlating a chat turn", () => {
+  assert.equal(
+    normalizeChatText("  ¿Qué explica\n   CREATE TABLE?  "),
+    "¿Qué explica CREATE TABLE?"
+  );
+});
+
+test("does not return an older answer or Gemini reasoning for a new question", () => {
+  const messages: ChatMessageSnapshot[] = [
+    { role: "user", text: "Explica herencia EER" },
+    { role: "assistant", text: "Defining Key Concepts...", complete: true },
+    { role: "user", text: "Explica CREATE TABLE" },
+    {
+      role: "assistant",
+      text: "Deciphering the Intent. I'm zeroing in on the request...",
+      complete: false,
+    },
+  ];
+
+  assert.equal(findCompletedTurnAnswer(messages, "Explica CREATE TABLE"), null);
+});
+
+test("returns only the completed answer paired with the exact user turn", () => {
+  const messages: ChatMessageSnapshot[] = [
+    { role: "user", text: "Explica herencia EER" },
+    { role: "assistant", text: "Respuesta EER", complete: true },
+    { role: "user", text: "Explica\nCREATE TABLE" },
+    {
+      role: "assistant",
+      text: "CREATE TABLE define una tabla y sus restricciones.",
+      complete: true,
+    },
+  ];
+
+  assert.equal(
+    findCompletedTurnAnswer(messages, "Explica CREATE TABLE"),
+    "CREATE TABLE define una tabla y sus restricciones."
+  );
+});
+
+test("uses the newest occurrence when the same question is submitted twice", () => {
+  const messages: ChatMessageSnapshot[] = [
+    { role: "user", text: "Lista las fuentes" },
+    { role: "assistant", text: "Respuesta anterior", complete: true },
+    { role: "user", text: "Lista las fuentes" },
+    { role: "assistant", text: "Respuesta actual", complete: true },
+  ];
+
+  assert.equal(findCompletedTurnAnswer(messages, "Lista las fuentes"), "Respuesta actual");
+});
+
+test("sanitizes UI controls while preserving paragraph spacing", () => {
+  assert.equal(
+    sanitizeAnswer("Primer párrafo.\n\nSegundo párrafo.\nmore_vert\n\n- Elemento\ncopy_all"),
+    "Primer párrafo.\n\nSegundo párrafo.\n\n- Elemento"
+  );
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CONFIG, applyBrowserOptions, getRuntimeConfig, withRuntimeConfig } from "../src/config.js";
+
+test("request-scoped browser options do not mutate global configuration", async () => {
+  const visible = applyBrowserOptions({ show: true, timeout_ms: 1234 });
+  const hidden = applyBrowserOptions({ show: false, timeout_ms: 5678 });
+
+  const [visibleResult, hiddenResult] = await Promise.all([
+    withRuntimeConfig(visible, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return getRuntimeConfig();
+    }),
+    withRuntimeConfig(hidden, async () => getRuntimeConfig()),
+  ]);
+
+  assert.equal(visibleResult.headless, false);
+  assert.equal(visibleResult.browserTimeout, 1234);
+  assert.equal(hiddenResult.headless, true);
+  assert.equal(hiddenResult.browserTimeout, 5678);
+  assert.equal(getRuntimeConfig(), CONFIG);
+});

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AddressInfo } from "node:net";
+import { startHttpTransport } from "../src/transport/http.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+test("HTTP health endpoint accepts local requests and rejects hostile origins", async () => {
+  const handle = await startHttpTransport({
+    port: 0,
+    host: "127.0.0.1",
+    connect: async () => undefined,
+  });
+
+  try {
+    const address = handle.server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}/healthz`;
+
+    const healthy = await fetch(url);
+    assert.equal(healthy.status, 200);
+
+    const hostile = await fetch(url, {
+      headers: { Origin: "https://attacker.example" },
+    });
+    assert.equal(hostile.status, 403);
+  } finally {
+    await handle.close();
+  }
+});
+
+test("non-loopback HTTP binding requires a bearer token", async () => {
+  await assert.rejects(
+    startHttpTransport({
+      port: 0,
+      host: "0.0.0.0",
+      connect: async () => undefined,
+    }),
+    /requires NOTEBOOKLM_HTTP_AUTH_TOKEN/
+  );
+});
+
+test("creates an independent MCP server for each concurrent HTTP client", async () => {
+  let serverCount = 0;
+  const handle = await startHttpTransport({
+    port: 0,
+    host: "127.0.0.1",
+    connect: async (transport) => {
+      const instance = ++serverCount;
+      const server = new Server(
+        { name: `test-server-${instance}`, version: "1.0.0" },
+        { capabilities: { tools: {} } }
+      );
+      server.setRequestHandler(ListToolsRequestSchema, async () => ({
+        tools: [
+          {
+            name: `tool-${instance}`,
+            description: "test tool",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      }));
+      await server.connect(transport);
+    },
+  });
+
+  const address = handle.server.address() as AddressInfo;
+  const endpoint = new URL(`http://127.0.0.1:${address.port}/mcp`);
+  const clientA = new Client({ name: "client-a", version: "1.0.0" });
+  const clientB = new Client({ name: "client-b", version: "1.0.0" });
+
+  try {
+    await Promise.all([
+      clientA.connect(new StreamableHTTPClientTransport(endpoint)),
+      clientB.connect(new StreamableHTTPClientTransport(endpoint)),
+    ]);
+    const [toolsA, toolsB] = await Promise.all([clientA.listTools(), clientB.listTools()]);
+
+    assert.equal(serverCount, 2);
+    assert.notEqual(toolsA.tools[0]?.name, toolsB.tools[0]?.name);
+  } finally {
+    await Promise.allSettled([clientA.close(), clientB.close()]);
+    await handle.close();
+  }
+});

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeNotebookUrl } from "../src/notebooklm/url.js";
+
+test("normalizes a valid NotebookLM URL", () => {
+  assert.equal(
+    normalizeNotebookUrl("https://notebooklm.google.com/notebook/abc_123-def#fragment"),
+    "https://notebooklm.google.com/notebook/abc_123-def"
+  );
+});
+
+test("accepts the current notebook.google.com host", () => {
+  assert.equal(
+    normalizeNotebookUrl("https://notebook.google.com/notebook/abc_123-def#fragment"),
+    "https://notebook.google.com/notebook/abc_123-def"
+  );
+});
+
+test("rejects non-NotebookLM and non-HTTPS URLs", () => {
+  assert.throws(() => normalizeNotebookUrl("http://notebooklm.google.com/notebook/abc"), /HTTPS/);
+  assert.throws(() => normalizeNotebookUrl("https://example.com/notebook/abc"), /host/);
+  assert.throws(() => normalizeNotebookUrl("https://notebooklm.google.com/"), /must match/);
+});


### PR DESCRIPTION
## Summary

This PR improves NotebookLM authentication, HTTP transport safety, concurrency, persistence, and local testing.

The immediate authentication failure was caused by NotebookLM now redirecting authenticated users to `https://notebook.google.com/`, while the server only recognized `notebooklm.google.com`. The setup flow therefore kept waiting even after a successful Google login.

## What changed

- Accept both the current `notebook.google.com` host and legacy `notebooklm.google.com` links.
- Detect successful authentication across every page in the persistent browser context.
- Preserve the existing Chrome profile in `setup_auth`; destructive profile cleanup remains the responsibility of `re_auth`.
- Save browser state and close Chrome automatically after detecting NotebookLM.
- Treat progress delivery as best-effort so a disconnected Inspector cannot cancel a long-running operation.
- Isolate per-request browser configuration with `AsyncLocalStorage`.
- Serialize browser operations per session and protect concurrent session creation.
- Create a separate MCP protocol server for each Streamable HTTP connection.
- Add bearer authentication for non-loopback HTTP binds, Host/Origin checks, body limits, and request timeouts.
- Validate NotebookLM URLs before navigation or persistence.
- Validate library/settings data and write it atomically with restrictive file permissions.
- Reduce simulated typing from repeated whole-field rewrites to incremental keyboard input.
- Update `@modelcontextprotocol/sdk` to 1.29.0 and require Node.js 22.13 or newer.
- Add local `mcp:smoke`, `mcp:auth`, and `mcp:ask` commands.
- Update documentation for the current NotebookLM domain and HTTP security settings.

## Developer and user impact

- First-time authentication once again completes automatically: state is persisted and the login browser closes.
- Existing profiles are no longer erased by repeated `setup_auth` calls.
- Concurrent HTTP clients and browser calls cannot overwrite one another's request-specific configuration.
- Remote HTTP deployments fail closed unless explicitly protected with a bearer token.
- Corrupt or partially written library/settings files no longer silently poison subsequent runs.

## Validation

- `npm run check`
  - Prettier
  - ESLint
  - TypeScript build
  - 7 passing tests
- `npm pack --dry-run`
- Live authentication against `https://notebook.google.com/`
  - NotebookLM detected
  - browser state saved
  - Chrome closed automatically
  - `get_health` returned `authenticated: true`
- Live `ask_question` against the active notebook
  - 25 critical cookies validated
  - persisted profile reused headlessly
  - NotebookLM returned a grounded answer

## Notes

`npm audit` reports no high or critical vulnerabilities. Two moderate advisories remain in the SDK's transitive `@hono/node-server` dependency; this project does not use Hono's affected static-file serving path. npm's suggested forced remediation would downgrade the MCP SDK and reintroduce more serious SDK advisories, so it was intentionally not applied.
