### PR TITLE
fix: unblock add_source and answer extraction on non-English UIs

### DIFF
--- a/src/notebooklm/chat.ts
+++ b/src/notebooklm/chat.ts
@@ -269,6 +269,22 @@ export async function waitForStableAnswer(
       const isPrior = ignoreSet.has(candidate);
 
       if (!isEcho && !isPrior) {
+        // Gemini streams its reasoning trace into the same node before the
+        // answer arrives. That prose is long, prose-shaped and stable for
+        // several polls, so `isPlaceholder` misses it and the streak counter
+        // returns the model's thoughts as the final answer. The two phases are
+        // only distinguishable structurally, so gate on the DOM.
+        if (
+          !isErrorMessage(candidate) &&
+          !isRateLimitText(candidate) &&
+          (await isStillThinking(page))
+        ) {
+          stableStreak = 0;
+          lastSeen = null;
+          await safeSleep(page, Math.min(pollIntervalMs, 400));
+          continue;
+        }
+
         // Loading placeholders ("Parsing the data…", "Thinking…", …) are
         // stable while Gemini is still working — the old code locked on to
         // them and returned them as the final answer. Filter them out.
@@ -301,6 +317,26 @@ export async function waitForStableAnswer(
   }
 
   return null;
+}
+
+/**
+ * Is the latest turn still Gemini's reasoning trace rather than the answer?
+ *
+ * The reasoning phase renders `<thinking-animation>` or a plain
+ * `<div class="md3-body-text">` inside `.message-text-content`; the finished
+ * answer replaces it with `<labs-tailwind-doc-viewer>`. The wording is both
+ * locale- and model-dependent, the DOM shape is not.
+ */
+async function isStillThinking(page: Page): Promise<boolean> {
+  return page
+    .locator(Selectors.chat.latestAnswerText)
+    .last()
+    .evaluate(
+      (el) =>
+        !el.querySelector("labs-tailwind-doc-viewer") &&
+        !!(el.querySelector(".md3-body-text") || el.querySelector("thinking-animation"))
+    )
+    .catch(() => false);
 }
 
 /**

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -133,16 +133,22 @@ export const Selectors = {
       'button[aria-label*="adicionar fonte" i]',
       'button[aria-label*="bron toevoegen" i]',
       'button[aria-label*="ソースを追加" i]',
+      'button[aria-label*="kaynak ekle" i]',
     ],
     /**
      * Real Material modal. `[role="dialog"]` is set by Angular synchronously
      * the moment the modal mounts — race-free against the `.mdc-dialog--open`
      * animation class and resistant to Material-UI version bumps. Avoid
      * `.cdk-overlay-pane` (matches every dropdown / emoji picker / menu).
+     *
+     * Scoped to `.mat-mdc-dialog-container`: NotebookLM keeps a hidden emoji
+     * picker in the DOM that also carries `role="dialog"` and precedes the real
+     * modal, so a bare `[role="dialog"]` + `.first()` resolved to the invisible
+     * palette and every overlay wait timed out.
      */
-    overlayPane: '[role="dialog"]',
-    overlayInput: '[role="dialog"] input[type="text"]:not([readonly])',
-    overlayTextarea: '[role="dialog"] textarea',
+    overlayPane: '.mat-mdc-dialog-container[role="dialog"]',
+    overlayInput: '.mat-mdc-dialog-container[role="dialog"] input[type="text"]:not([readonly])',
+    overlayTextarea: '.mat-mdc-dialog-container[role="dialog"] textarea',
     /**
      * Source-type buttons in the Add-source overlay. Google ships them
      * *without* aria-labels — the only stable, language-agnostic anchor is
@@ -212,6 +218,7 @@ export const Selectors = {
       'button.mdc-button--raised:has-text("Inserisci")',
       'button.mdc-button--raised:has-text("Invoegen")',
       'button.mdc-button--raised:has-text("挿入")',
+      'button.mdc-button--raised:has-text("Ekle")',
       'button:has-text("Insert")',
       'button:has-text("Einfügen")',
       'button:has-text("Hinzufügen")',
@@ -228,6 +235,9 @@ export const Selectors = {
       'button:has-text("Toevoegen")',
       'button:has-text("挿入")',
       'button:has-text("追加")',
+      // Exact match on purpose: `has-text` is a substring match and would also
+      // hit the Turkish "Kaynak ekle" (add source) button.
+      'button:text-is("Ekle")',
       'button:has-text("Add")',
       'button:has-text("Submit")',
       'button[type="submit"]',

--- a/src/notebooklm/sources.ts
+++ b/src/notebooklm/sources.ts
@@ -206,6 +206,15 @@ async function openAddSourceOverlay(page: Page): Promise<void> {
     log.warning(`  ⚠️  Add-source button click failed (${err}), trying ?addSource=true URL fallback`);
   }
 
+  // The click frequently lands even though Playwright reports a hit-target
+  // timeout: the dialog's own backdrop covers the button while the actionability
+  // check retries. Re-check here, otherwise the `addSource=true` guard below
+  // sees the URL the click already navigated to and throws for nothing.
+  if (await isOverlayVisible(page)) {
+    log.info("  ✅ Add-source dialog opened despite click timeout");
+    return;
+  }
+
   // URL fallback — useful when the sidebar button is hidden or covered.
   const url = page.url();
   if (url && /\/notebook\//.test(url) && !url.includes("addSource=true")) {


### PR DESCRIPTION
## What

Four fixes, found while running v2.0.0 against a **Turkish (`tr`) NotebookLM UI**. Three of them make `add_source` fail outright; the fourth makes `ask_question` return the wrong text on any locale.

## 1. `overlayPane` resolved to a hidden emoji picker

NotebookLM keeps an emoji palette in the DOM that also carries `role="dialog"` and sits **before** the real modal. So `[role="dialog"]` + `.first()` always resolved to the invisible palette, every overlay wait timed out, and `add_source` failed with:

```
Could not open the "Add source" dialog
```

Observed live:

```
DIALOGS: [
 { cls: "emoji-keyboard__container ...", aria: "Emoji karakterleri paleti", visible: false },
 { cls: "mat-mdc-dialog-container mdc-dialog ... mdc-dialog--open", visible: true }
]
```

Scoped `overlayPane` / `overlayInput` / `overlayTextarea` to `.mat-mdc-dialog-container`.

## 2. `openAddSourceOverlay` threw after a click that had worked

The click lands, the dialog opens, the URL becomes `?addSource=true` — but Playwright still reports a hit-target timeout, because the dialog's own backdrop covers the button while the actionability check retries. Control fell into the URL fallback, which then skipped itself (`addSource=true` was already in the URL) and threw.

Added a visibility re-check between the two.

## 3. Missing Turkish locale strings

- `insertConfirm`: `"Ekle"` (confirm button)
- `addButton`: `"kaynak ekle"` aria-label

`:text-is` is used for the confirm button deliberately — `has-text` is a substring match and would also hit the `"Kaynak ekle"` (add source) button.

## 4. `ask_question` returned Gemini's reasoning trace

Not locale-specific. Gemini streams its reasoning into the same `.message-text-content` node before the answer arrives. That text is long, prose-shaped, and stable across several polls, so `isPlaceholder` doesn't catch it and the streak counter locks on and returns it. Typical result:

> Assessing the Inquiry — I'm currently dissecting the user's query regarding the resource list…

The phases differ **structurally**, not textually:

| phase | DOM inside `.message-text-content` |
|---|---|
| reasoning | `<thinking-animation>` / `<div class="md3-body-text">` |
| answer | `<labs-tailwind-doc-viewer>` |

`isStillThinking()` gates on that. Wording is locale- and model-dependent; the DOM shape is not. Error and rate-limit texts keep their existing fast path, so genuine failures still return immediately instead of waiting out the timeout.

## Verification

Against live `notebooklm.google.com`, `tr` locale, on the built output of this branch:

- `add_source` (text): source list `0 → 1 → 2`, both via the module directly and through the MCP tool
- `ask_question`: final answer in ~8 s, with citations, instead of the reasoning trace
- `npm run lint`: 0 errors (1 pre-existing warning in `src/transport/http.ts`, untouched)
- `npm run build`: clean

`prettier --check` still flags `selectors.ts` and `sources.ts` — both were already flagged on a pristine checkout of `main`, so I left the formatting alone rather than bury this diff in unrelated reflows.

## Notes

I don't have a non-Turkish locale to regression-test against, so an extra pair of eyes on the `Ekle` / `text-is` choice would be welcome. The `.mat-mdc-dialog-container` scoping and the reasoning-trace gate should be locale-independent.