### PR TITLE
fix: recognize notebook.google.com host so post-rebrand auth persists (#76)

### DIFF
--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -18,6 +18,7 @@ import { existsSync } from "fs";
 import path from "path";
 import { CONFIG, NOTEBOOKLM_AUTH_URL } from "../config.js";
 import { log } from "../utils/logger.js";
+import { isNotebookAppUrl } from "../utils/notebook-domain.js";
 import {
   getPreferredChannel,
   isChannelFailure,
@@ -278,7 +279,9 @@ export class AuthManager {
    * Perform interactive login
    * User will see a browser window and login manually
    *
-   * SIMPLE & RELIABLE: Just wait for URL to change to notebooklm.google.com
+   * SIMPLE & RELIABLE: Just wait for the URL to land on the notebook app on
+   * either host — notebooklm.google.com OR the notebook.google.com rebrand alias
+   * (see isNotebookAppUrl; some Workspace accounts resolve to notebook.google.com).
    */
   async performLogin(page: Page, sendProgress?: ProgressCallback): Promise<boolean> {
     try {
@@ -320,7 +323,7 @@ export class AuthManager {
           }
 
           // ✅ SIMPLE: Check if we're on NotebookLM (any path!)
-          if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+          if (isNotebookAppUrl(currentUrl)) {
             await sendProgress?.("Login successful! NotebookLM detected!", 9, 10);
             log.success("✅ Login successful! NotebookLM URL detected.");
             log.success(`✅ Current URL: ${currentUrl}`);
@@ -344,7 +347,7 @@ export class AuthManager {
 
       // Timeout reached - final check
       const currentUrl = page.url();
-      if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+      if (isNotebookAppUrl(currentUrl)) {
         await sendProgress?.("Login successful (detected on timeout check)!", 9, 10);
         log.success("✅ Login successful (detected on timeout check)");
         return true;
@@ -491,7 +494,7 @@ export class AuthManager {
       } else {
         log.error(`  ❌ Stuck on Google accounts page: ${currentUrl.slice(0, 80)}...`);
       }
-    } else if (currentUrl.includes("notebooklm.google.com")) {
+    } else if (isNotebookAppUrl(currentUrl)) {
       log.warning("  ⚠️  Reached NotebookLM but couldn't detect successful login");
       log.info("  💡 This might be a timing issue - try again");
     } else {
@@ -508,7 +511,7 @@ export class AuthManager {
   /**
    * Wait for Google to redirect to NotebookLM after successful login (SIMPLE & RELIABLE)
    *
-   * Just checks if URL changes to notebooklm.google.com - no complex UI element searching!
+   * Just checks if the URL lands on the notebook app (either host) - no complex UI element searching!
    * Matches the simplified approach used in performLogin().
    */
   private async waitForRedirectAfterLogin(page: Page, deadline: number): Promise<boolean> {
@@ -519,7 +522,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookAppUrl(currentUrl)) {
           log.success("    ✅ NotebookLM URL detected!");
           // Short wait to ensure page is loaded
           await page.waitForTimeout(2000);
@@ -539,7 +542,7 @@ export class AuthManager {
   /**
    * Wait for NotebookLM to load (SIMPLE & RELIABLE)
    *
-   * Just checks if URL starts with notebooklm.google.com - no complex UI element searching!
+   * Just checks if the URL is on the notebook app (either host) - no complex UI element searching!
    * Matches the simplified approach used in performLogin().
    */
   private async waitForNotebook(page: Page, timeoutMs: number): Promise<boolean> {
@@ -550,7 +553,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookAppUrl(currentUrl)) {
           log.success("  ✅ NotebookLM URL detected");
           return true;
         }

--- a/src/session/browser-session.ts
+++ b/src/session/browser-session.ts
@@ -39,6 +39,7 @@ import {
 } from "../notebooklm/audio.js";
 import { CONFIG } from "../config.js";
 import { log } from "../utils/logger.js";
+import { isNotebookAppUrl } from "../utils/notebook-domain.js";
 import type { SessionInfo, ProgressCallback } from "../types.js";
 import { RateLimitError } from "../errors.js";
 
@@ -285,16 +286,8 @@ export class BrowserSession {
     }
   }
 
-  private getOriginFromUrl(url: string): string | null {
-    try {
-      return new URL(url).origin;
-    } catch {
-      return null;
-    }
-  }
-
   /**
-   * Safely restore sessionStorage when the page is on the expected origin
+   * Safely restore sessionStorage once the page is on a notebook host
    */
   private async restoreSessionStorage(
     sessionData: Record<string, string>,
@@ -305,21 +298,20 @@ export class BrowserSession {
       return;
     }
 
-    const targetOrigin = this.getOriginFromUrl(this.notebookUrl);
-    if (!targetOrigin) {
-      log.warning(`  ⚠️  Unable to determine target origin for sessionStorage restore`);
-      return;
-    }
-
     let restored = false;
 
+    // NotebookLM resolves to one of two hosts depending on the account
+    // (notebooklm.google.com, or the notebook.google.com rebrand alias — some
+    // Workspace tenants land there). After Google's redirect the page can settle
+    // on a different host than the stored notebook URL, so restore sessionStorage
+    // once the page is on EITHER notebook host instead of requiring an exact
+    // origin match — otherwise a Workspace session never gets its state restored.
     const applyToPage = async (): Promise<boolean> => {
       if (!this.page) {
         return false;
       }
 
-      const currentOrigin = this.getOriginFromUrl(this.page.url());
-      if (currentOrigin !== targetOrigin) {
+      if (!isNotebookAppUrl(this.page.url())) {
         return false;
       }
 

--- a/src/utils/notebook-domain.ts
+++ b/src/utils/notebook-domain.ts
@@ -1,0 +1,22 @@
+/**
+ * NotebookLM is reachable at two hosts Google keeps in sync by redirects:
+ *   notebooklm.google.com  (canonical)   and   notebook.google.com  (rebrand alias).
+ * Which one an AUTHENTICATED session lands on is account-dependent: personal →
+ * notebooklm, some Workspace tenants → notebook (their OSID service cookie is bound
+ * there). So host checks must accept BOTH.
+ *
+ * Parses the URL (not substring) so a host inside a `continue=` query param can't
+ * false-match, and excludes `/login` so login-success detection doesn't fire on the
+ * pre-auth page and save browser state before the OSID cookie is set.
+ */
+const NOTEBOOK_HOSTS = ["notebooklm.google.com", "notebook.google.com"];
+
+/** True once the page is on the authenticated notebook app (either host, not /login). */
+export function isNotebookAppUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return NOTEBOOK_HOSTS.includes(u.hostname) && !u.pathname.startsWith("/login");
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes `setup_auth` / `re_auth` always failing after the 2026-07-16 **NotebookLM → Gemini Notebook** rebrand. Closes #76.

Google now lands some authenticated sessions on **`notebook.google.com`** (no "lm") instead of `notebooklm.google.com`. The login-success check was hardcoded to the old host in four places, so the tool never recognized a successful login, polled the full 10 minutes, returned `false`, and **never persisted cookies** — every subsequent `get_health` reported `authenticated: false` even though the browser was sitting on a fully logged-in notebook page.

## Root cause — why cookies went missing

The chain, all in `src/auth/auth-manager.ts`:

1. `performLogin()` polls `page.url()` waiting for success, checking `currentUrl.startsWith("https://notebooklm.google.com/")` (main loop **and** post-timeout final check).
2. `waitForRedirectAfterLogin()` and `waitForNotebook()` use the same hardcoded check.
3. A Workspace session lands on `notebook.google.com/...`, so **none** of the four checks ever match.
4. `performLogin()` returns `false`. Its only caller then **skips `saveBrowserState()`** — the method that runs `context.storageState({ path: state.json })`.
5. Because `saveBrowserState()` never runs, `state.json` is never written, so the persisted cookie set — **including the host-scoped `OSID` / `__Secure-OSID` service cookies** that authorize the notebook app — is lost. Next run: `authenticated: false`.

So the bug isn't a cookie-*capture* bug; it's a *recognition* bug that gates the capture. `storageState()` grabs every cookie in the context regardless of host — we just have to correctly detect that we've arrived so it gets called.

## The fix

One helper, `src/utils/notebook-domain.ts`:

```ts
const NOTEBOOK_HOSTS = ["notebooklm.google.com", "notebook.google.com"];

export function isNotebookAppUrl(url: string): boolean {
  try {
    const u = new URL(url);
    return NOTEBOOK_HOSTS.includes(u.hostname) && !u.pathname.startsWith("/login");
  } catch {
    return false;
  }
}
```

- **Accept both hosts** — the actual fix for #76 (matches the reporter's suggested patch).
- **Parse the URL instead of substring-matching** — so a notebook host appearing inside a sign-in `continue=` query param on `accounts.google.com` can't false-match.
- **Exclude `/login`** — the flow can transiently sit on `notebooklm.google.com/login` before Google redirects a Workspace session onward. Firing success there would call `saveBrowserState()` *before* the `OSID` service cookie is set, persisting a half-authenticated state. This is the subtle "logged in but cookies missing" variant; the `/login` guard prevents it.

Wired into the four `auth-manager.ts` detection sites (plus the failure-diagnostic branch). Also fixes the same single-host assumption in the query path: `browser-session.ts`'s `restoreSessionStorage()` only re-injected `sessionStorage` when the page origin exactly equalled the stored `notebookUrl` origin, which silently never happened for a Workspace session redirected to `notebook.google.com`; it now restores on either notebook host (and the now-dead `getOriginFromUrl()` helper is removed).

Net: **+42 / −25**, one new 22-line file, no new dependencies.

## Corroborating evidence (independent investigation on the roomi-fields fork)

Same rebrand was investigated in depth on the sibling `@roomi-fields/notebooklm-mcp` project (their PR [#19](https://github.com/roomi-fields/notebooklm-mcp/pull/19)). Findings that back the account-dependent-host model here:

- **`OSID` is host-scoped.** For a Workspace account (`*.google.co.th`): `notebook.google.com` → 20 cookies **including `OSID` + `__Secure-OSID`** (service session present); `notebooklm.google.com` → 15 cookies, broad `.google.com` only, **no `OSID`**. That's *why* the app canonicalizes per account: the host holding `OSID` is where that account's authenticated app lives.
- **Direction:** anonymously `notebook.google.com` 302s to `notebooklm.google.com` (canonical), so this PR deliberately does **not** pin navigation to either host — it only broadens *recognition*. Navigation here already uses the notebook URL as stored and follows Google's redirect, so no navigation change is needed (pinning was tried and reverted on the other fork).

## Scope notes

- No URL-validation rejection gate exists in this repo (unlike the sibling project), so no validation change is needed — the fix is confined to detection + the sessionStorage origin gate.
- **Out of scope:** a separate query-path timeout (`ask_question` → "Timeout waiting for response", cf. #50 / #74) reproduces independently of auth and is unrelated to this host fix.

## Verification

- `npm run build` clean; `npm run lint` no new errors; changed files pass `prettier`.
- Standalone assertion run on `isNotebookAppUrl` (6 cases incl. the exact `notebook.google.com/?pli=1` landing, the `/login` guard, the `continue=` false-match, a look-alike host, and unparseable input) — all pass. (No test was committed: this repo has no test runner, and adding one for one function is out of scope — happy to add a `*.test.ts` if you wire up a runner.)
- **Live:** on a patched build, `re_auth` completed in ~46 s with `authenticated: true`, and `get_health` confirmed it — the exact flow that fails on `main`.
