### PR TITLE
fix support for current NotebookLM UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "tsx watch src/index.ts",
     "prepare": "npm run build",
     "test": "tsx src/index.ts",
+    "test:unit": "tsx --test src/auth/auth-manager.test.ts src/notebooklm/chat.test.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write src",

--- a/src/auth/auth-manager.test.ts
+++ b/src/auth/auth-manager.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isNotebookLmUrl } from "./auth-manager.js";
+
+test("recognizes both NotebookLM production domains", () => {
+  assert.equal(isNotebookLmUrl("https://notebooklm.google.com/"), true);
+  assert.equal(isNotebookLmUrl("https://notebooklm.google.com/notebook/abc"), true);
+  assert.equal(isNotebookLmUrl("https://notebook.google.com/?pli=1"), true);
+  assert.equal(isNotebookLmUrl("https://notebook.google.com/notebook/abc"), true);
+});
+
+test("rejects lookalike and unrelated domains", () => {
+  assert.equal(isNotebookLmUrl("https://notebook.google.com.evil.example/"), false);
+  assert.equal(isNotebookLmUrl("https://accounts.google.com/"), false);
+});

--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -46,6 +46,12 @@ const CRITICAL_COOKIE_NAMES = [
   "__Secure-3PSID", // Secure variants
 ];
 
+const NOTEBOOKLM_ORIGINS = ["https://notebooklm.google.com/", "https://notebook.google.com/"];
+
+export function isNotebookLmUrl(url: string): boolean {
+  return NOTEBOOKLM_ORIGINS.some((origin) => url.startsWith(origin));
+}
+
 export class AuthManager {
   private stateFilePath: string;
   private sessionFilePath: string;
@@ -320,7 +326,7 @@ export class AuthManager {
           }
 
           // ✅ SIMPLE: Check if we're on NotebookLM (any path!)
-          if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+          if (isNotebookLmUrl(currentUrl)) {
             await sendProgress?.("Login successful! NotebookLM detected!", 9, 10);
             log.success("✅ Login successful! NotebookLM URL detected.");
             log.success(`✅ Current URL: ${currentUrl}`);
@@ -344,7 +350,7 @@ export class AuthManager {
 
       // Timeout reached - final check
       const currentUrl = page.url();
-      if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+      if (isNotebookLmUrl(currentUrl)) {
         await sendProgress?.("Login successful (detected on timeout check)!", 9, 10);
         log.success("✅ Login successful (detected on timeout check)");
         return true;
@@ -491,7 +497,7 @@ export class AuthManager {
       } else {
         log.error(`  ❌ Stuck on Google accounts page: ${currentUrl.slice(0, 80)}...`);
       }
-    } else if (currentUrl.includes("notebooklm.google.com")) {
+    } else if (isNotebookLmUrl(currentUrl)) {
       log.warning("  ⚠️  Reached NotebookLM but couldn't detect successful login");
       log.info("  💡 This might be a timing issue - try again");
     } else {
@@ -519,7 +525,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookLmUrl(currentUrl)) {
           log.success("    ✅ NotebookLM URL detected!");
           // Short wait to ensure page is loaded
           await page.waitForTimeout(2000);
@@ -550,7 +556,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookLmUrl(currentUrl)) {
           log.success("  ✅ NotebookLM URL detected");
           return true;
         }

--- a/src/notebooklm/chat.test.ts
+++ b/src/notebooklm/chat.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sanitizeAnswer } from "./chat.js";
+import { Selectors } from "./selectors.js";
+
+test("targets the current NotebookLM document viewer for assistant prose", () => {
+  assert.equal(
+    Selectors.chat.answerText,
+    ".to-user-container .message-text-content labs-tailwind-doc-viewer"
+  );
+  assert.equal(Selectors.chat.latestAnswerText, Selectors.chat.answerText);
+});
+
+test("removes the current UI thinking label without changing answer prose", () => {
+  assert.equal(
+    sanitizeAnswer("Thoughts\nI am an intelligent memory assistant."),
+    "I am an intelligent memory assistant."
+  );
+});

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -30,8 +30,8 @@
 export const Selectors = {
   chat: {
     answerContainer: ".to-user-container",
-    answerText: ".to-user-container .message-text-content",
-    latestAnswerText: ".to-user-container:last-child .message-text-content",
+    answerText: ".to-user-container .message-text-content labs-tailwind-doc-viewer",
+    latestAnswerText: ".to-user-container .message-text-content labs-tailwind-doc-viewer",
     /**
      * Chat textarea. The class is shared across locales; aria-labels are a
      * fallback for older builds where the class was different.
@@ -394,6 +394,7 @@ export const Selectors = {
     "keep_pin",
     "copy_all",
     "arrow_forward",
+    "Thoughts",
   ]),
 } as const;
 


### PR DESCRIPTION
## What changed

- Recognize both `notebooklm.google.com` and the current `notebook.google.com` production domain during authentication.
- Extract assistant prose from the current `labs-tailwind-doc-viewer` response component.
- Remove the standalone `Thoughts` UI label from returned answers.
- Add focused regression tests for domain detection, response selection, and sanitization.

## Why

Google now redirects successful NotebookLM logins to `https://notebook.google.com/`. The existing authentication checks only accepted `https://notebooklm.google.com/`, so valid logins waited until timeout and were reported as failures.

The current response UI also places a `Thoughts` label and the generated prose inside a document-viewer component. Selecting the broader message container caused the MCP to return UI labels such as `Thoughts` or `Save to note` instead of the actual answer.

## Impact

Users on the current NotebookLM UI can complete authentication and receive the generated response text through `ask_question`.

## Validation

- `npm run test:unit` — 4 tests passed.
- Targeted Prettier check — passed.
- Targeted ESLint check — passed.
- `npx tsc --noEmit` — passed.
- Live MCP verification against `notebook.google.com` returned a complete generated response instead of the `Thoughts` label.

The repository's Windows `npm ci` reached a successful TypeScript build but its Unix-only `postbuild` command (`chmod +x dist/index.js`) is not available under `cmd.exe`; the compiler was therefore also run directly.
