### PR TITLE
fix(chat): return this turn's completed answer, not a reasoning trace or a stale turn

### DIFF
--- a/src/notebooklm/chat.ts
+++ b/src/notebooklm/chat.ts
@@ -181,6 +181,37 @@ function isPlaceholder(text: string): boolean {
   return false;
 }
 
+/**
+ * True while NotebookLM is still generating the current turn.
+ *
+ * NotebookLM disables the query textarea (placeholder switches to
+ * "Responding…") for the whole time Gemini works, and re-enables it the moment
+ * the turn completes — an exact, language-agnostic "still working" signal.
+ *
+ * Needed because current NotebookLM streams Gemini's *reasoning trace* into the
+ * same `.message-text-content` node as the answer. The trace is ordinary prose
+ * ("Initiating the Analysis / I'm now diving into the user's request…"), so
+ * `isPlaceholder()` misses it, and it sits unchanged far longer than
+ * `stablePolls` × `pollIntervalMs` — the stability detector would otherwise
+ * return the reasoning as the final answer.
+ *
+ * Anchors on the class-based primary selector only. The page also mounts a
+ * "Search the web for new sources" textarea that sits *earlier* in the DOM, so
+ * matching the whole `queryInput` alternation and taking `.first()` can latch
+ * onto the wrong box.
+ *
+ * Fails open (returns `false`) when the textarea can't be found, so a future UI
+ * change degrades to the previous stability-only behaviour rather than hanging.
+ */
+async function isGenerating(page: Page): Promise<boolean> {
+  const [primaryQueryInput] = Selectors.chat.queryInput;
+  try {
+    return await page.locator(primaryQueryInput).first().isDisabled({ timeout: 1_000 });
+  } catch {
+    return false;
+  }
+}
+
 function isErrorMessage(text: string): boolean {
   const lower = text.toLowerCase();
   return ERROR_SNIPPETS.some((s) => lower.includes(s));
@@ -202,6 +233,18 @@ export interface AskOptions {
   ignoreTexts?: string[];
   /** How many consecutive identical polls count as "answer settled". Default 3. */
   stablePolls?: number;
+  /**
+   * Streak at which text is accepted even while the page still reports that it
+   * is generating. Guards against a UI change breaking the "generating" probe.
+   * Default 20 (≈15 s at the default cadence).
+   */
+  stableFallbackPolls?: number;
+  /**
+   * Polls to spend waiting for the question-anchored read to match before
+   * falling back to "latest answer container". Bounded so an unmatched anchor
+   * degrades instead of blocking to `timeoutMs`. Default 40 (≈30 s).
+   */
+  newTurnGracePolls?: number;
 }
 
 /**
@@ -234,6 +277,8 @@ export async function waitForStableAnswer(
     pollIntervalMs = 750,
     ignoreTexts = [],
     stablePolls = 3,
+    stableFallbackPolls = 20,
+    newTurnGracePolls = 40,
   } = options;
 
   const deadline = Date.now() + timeoutMs;
@@ -258,7 +303,14 @@ export async function waitForStableAnswer(
 
     let candidate: string | null = null;
     try {
-      candidate = await readLatestAnswer(page);
+      // Prefer the question-anchored read; it is the only one that guarantees
+      // the text belongs to *this* turn. Fall back to "latest container" only
+      // after the grace window, so an unmatched anchor degrades instead of
+      // blocking to `timeoutMs`.
+      candidate = question ? await readAnswerForQuestion(page, question) : null;
+      if (!candidate && (!question || pollCount > newTurnGracePolls)) {
+        candidate = await readLatestAnswer(page);
+      }
     } catch (err) {
       if (isRecoverable(err)) throw err;
       // Non-fatal extraction blip — try again next tick.
@@ -287,7 +339,15 @@ export async function waitForStableAnswer(
 
         if (candidate === lastSeen) {
           stableStreak++;
-          if (stableStreak >= stablePolls) {
+          // Stable text is only final once the turn itself has finished —
+          // otherwise a settled reasoning trace reads as a settled answer.
+          // The streak ceiling is a safety valve: if the "generating" probe ever
+          // reads true forever (UI change), fall back to stability alone rather
+          // than blocking until `timeoutMs`.
+          if (stableStreak >= stableFallbackPolls) {
+            return candidate;
+          }
+          if (stableStreak >= stablePolls && !(await isGenerating(page))) {
             return candidate;
           }
         } else {
@@ -304,15 +364,78 @@ export async function waitForStableAnswer(
 }
 
 /**
+ * Read the answer belonging to a *specific* question.
+ *
+ * "Last answer container in the DOM" is not a reliable handle on the current
+ * turn: NotebookLM virtualises the chat list, so the rendered window depends on
+ * scroll position and can exclude the newest turn entirely. Reading it that way
+ * returns an unrelated earlier answer — observed repeatedly (asked about the
+ * lamps of the ten virgins, got an answer about hope).
+ *
+ * Instead, locate the user's own turn matching this question and take the first
+ * answer container after it in document order. Returns `null` when the turn is
+ * not currently rendered, which the caller treats as "keep waiting".
+ */
+async function readAnswerForQuestion(page: Page, question: string): Promise<string | null> {
+  const probe = question.trim().replace(/\s+/g, " ").slice(0, 60).toLowerCase();
+  if (!probe) return null;
+
+  try {
+    const raw = await page.evaluate(
+      ({ probeText, questionSel, answerSel, textSel }) => {
+        const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+        const nodes = Array.from(document.querySelectorAll(`${questionSel}, ${answerSel}`));
+
+        let anchor = -1;
+        nodes.forEach((node, i) => {
+          if (
+            node.matches(questionSel) &&
+            norm((node as HTMLElement).innerText).includes(probeText)
+          ) {
+            anchor = i; // keep the last match — the most recent ask
+          }
+        });
+        if (anchor === -1) return null;
+
+        for (let i = anchor + 1; i < nodes.length; i++) {
+          if (nodes[i].matches(answerSel)) {
+            const body = nodes[i].querySelector(textSel) as HTMLElement | null;
+            return body ? body.innerText : null;
+          }
+        }
+        return null;
+      },
+      {
+        probeText: probe,
+        questionSel: Selectors.chat.questionContainer,
+        answerSel: Selectors.chat.answerContainer,
+        textSel: ".message-text-content",
+      }
+    );
+
+    if (!raw) return null;
+    const cleaned = sanitizeAnswer(raw);
+    return cleaned.length > 0 ? cleaned : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read the latest answer container's text and strip UI-control leakage.
- * Uses `:last-child` so we always target the most recent turn.
+ *
+ * Deliberately uses the unqualified `answerText` selector, NOT
+ * `latestAnswerText`. The latter carries a `:last-child` qualifier, which keeps
+ * only containers that happen to be their parent's final child — the newest
+ * turn is often not, because sibling nodes (action rows, citation chrome) mount
+ * alongside it. `.last()` then silently falls back to some *older* turn, so a
+ * completely unrelated earlier answer is returned as if it were this turn's.
+ * Taking the last match of all answer containers is the actual "most recent
+ * turn" and matches what the page shows.
  */
 async function readLatestAnswer(page: Page): Promise<string | null> {
   try {
-    const raw = await page
-      .locator(Selectors.chat.latestAnswerText)
-      .last()
-      .innerText({ timeout: 2_000 });
+    const raw = await page.locator(Selectors.chat.answerText).last().innerText({ timeout: 2_000 });
     const cleaned = sanitizeAnswer(raw);
     return cleaned.length > 0 ? cleaned : null;
   } catch {

--- a/src/notebooklm/selectors.ts
+++ b/src/notebooklm/selectors.ts
@@ -30,6 +30,8 @@
 export const Selectors = {
   chat: {
     answerContainer: ".to-user-container",
+    /** The user's own turn. Used to anchor extraction to a specific question. */
+    questionContainer: ".from-user-container",
     answerText: ".to-user-container .message-text-content",
     latestAnswerText: ".to-user-container:last-child .message-text-content",
     /**
@@ -313,7 +315,7 @@ export const Selectors = {
      * contains the Download item.
      */
     audioMoreMenuButton: [
-      "artifact-library-item button:has(mat-icon:text-is(\"more_vert\"))",
+      'artifact-library-item button:has(mat-icon:text-is("more_vert"))',
       'artifact-library-item button[aria-label*="mehr" i]',
       'artifact-library-item button[aria-label*="more" i]',
       'artifact-library-item button[aria-label*="plus" i]',


### PR DESCRIPTION
Fixes the two `ask_question` failure modes tracked in #74 / #78 and #72. Both were diagnosed against the live DOM rather than inferred, and each is verified end-to-end.

Only `src/notebooklm/chat.ts` and `src/notebooklm/selectors.ts` change — no call-site or config changes, no new options required of callers.

## 1. Reasoning trace returned as the answer (#74, #78)

NotebookLM streams Gemini's extended-thinking block into the same `.message-text-content` node as the answer. It's ordinary prose, so `isPlaceholder()` never matches it, and it sits unchanged well past `stablePolls` × `pollIntervalMs` (2.25s) — so the stability detector accepts it as final.

Measured DOM state across one turn, sampled every 2s:

| t | `textarea.query-box-input` | answer node |
|---|---|---|
| 2–14s | `disabled`, placeholder `"Responding…"` | short loaders |
| 16–18s | `disabled` | reasoning trace (len 315 → 429) |
| 20s | `disabled` | real answer appears |
| **22s** | **enabled**, `"Start typing…"` | complete |

**Fix:** gate acceptance on the query textarea being re-enabled. NotebookLM disables it for the duration of the turn, which makes it exact and locale-independent — no language strings involved.

Two details that matter for anyone reviewing:

- `isGenerating()` anchors on the class selector `textarea.query-box-input` **only**, not `joinAlt(Selectors.chat.queryInput)` + `.first()`. A "Search the web for new sources" textarea sits earlier in the DOM and is never disabled, so the alternation latches onto the wrong element and the gate silently no-ops.
- Adds `stableFallbackPolls` (default 20): accept on a long stable streak even if the probe still reports "generating", so a future UI change degrades to today's behaviour instead of blocking until `timeoutMs`. An earlier version of this patch without the valve hung for the full 10 minutes.

This also explains why `BROWSER_TIMEOUT` / `ANSWER_TIMEOUT_MS` don't help (#78): they're ceilings, and `stablePolls` isn't plumbed to any env var.

## 2. An unrelated earlier turn returned as the answer (#72)

Reproduced on **en-US**, so this isn't the ko-KR/#69 issue it was tentatively filed under.

| Asked | Returned |
|---|---|
| "List the source titles and summarise the subject matter" | Robert Downey Jr. on a good life |
| "What does it mean to 'tend and keep' the garden in Genesis 2:15?" | verses on the 10% tithe |
| "What does the 'oil' in the lamps of the ten virgins represent?" | an answer about hope |

The question is submitted and answered correctly — reading the `.from-user-container` turns back confirms the exact question was recorded with the right answer in the following `.to-user-container`. The defect is purely in which node gets read.

`Selectors.chat.latestAnswerText` carries a `:last-child` qualifier that keeps only containers which are their parent's final child; the newest turn often isn't, so `.last()` falls through to an older one. But **removing that qualifier alone did not fix it** — container counts don't behave like an append-only list (10 on load, 11 during a live turn, 10 after reload), so "last container in the DOM" tracks scroll position rather than recency.

**Fix:** `readAnswerForQuestion()` anchors on the question — locate the last `.from-user-container` containing the first 60 chars of the question just submitted, then take the first `.to-user-container` after it in document order. Falls back to the previous "latest container" read only after `newTurnGracePolls` (default 40), so an unmatched anchor degrades instead of hanging. Adds `Selectors.chat.questionContainer` for the anchor.

These two interact: while #74 is unfixed, #72 is invisible, because you never get far enough to see which turn was read.

## Verification

Four end-to-end runs through the MCP stdio transport against a real notebook, each with a distinct question; every answer matched its question, ~24s per turn. `tsc` clean, ESLint clean, Prettier clean.

Environment: v2.0.0, Windows 11, Chrome channel, en-US.
