### PR TITLE
fix: accept notebook.google.com so setup_auth works after the Gemini Notebook rebrand

### DIFF
--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -16,7 +16,7 @@ import type { BrowserContext, ElementHandle, Page } from "patchright";
 import fs from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { CONFIG, NOTEBOOKLM_AUTH_URL } from "../config.js";
+import { CONFIG, NOTEBOOKLM_AUTH_URL, isNotebookLmUrl } from "../config.js";
 import { log } from "../utils/logger.js";
 import {
   getPreferredChannel,
@@ -320,7 +320,7 @@ export class AuthManager {
           }
 
           // ✅ SIMPLE: Check if we're on NotebookLM (any path!)
-          if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+          if (isNotebookLmUrl(currentUrl)) {
             await sendProgress?.("Login successful! NotebookLM detected!", 9, 10);
             log.success("✅ Login successful! NotebookLM URL detected.");
             log.success(`✅ Current URL: ${currentUrl}`);
@@ -344,7 +344,7 @@ export class AuthManager {
 
       // Timeout reached - final check
       const currentUrl = page.url();
-      if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+      if (isNotebookLmUrl(currentUrl)) {
         await sendProgress?.("Login successful (detected on timeout check)!", 9, 10);
         log.success("✅ Login successful (detected on timeout check)");
         return true;
@@ -491,7 +491,7 @@ export class AuthManager {
       } else {
         log.error(`  ❌ Stuck on Google accounts page: ${currentUrl.slice(0, 80)}...`);
       }
-    } else if (currentUrl.includes("notebooklm.google.com")) {
+    } else if (isNotebookLmUrl(currentUrl)) {
       log.warning("  ⚠️  Reached NotebookLM but couldn't detect successful login");
       log.info("  💡 This might be a timing issue - try again");
     } else {
@@ -519,7 +519,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookLmUrl(currentUrl)) {
           log.success("    ✅ NotebookLM URL detected!");
           // Short wait to ensure page is loaded
           await page.waitForTimeout(2000);
@@ -550,7 +550,7 @@ export class AuthManager {
         const currentUrl = page.url();
 
         // Simple check: Are we on NotebookLM?
-        if (currentUrl.startsWith("https://notebooklm.google.com/")) {
+        if (isNotebookLmUrl(currentUrl)) {
           log.success("  ✅ NotebookLM URL detected");
           return true;
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,11 +21,37 @@ import path from "path";
 const paths = envPaths("notebooklm-mcp", { suffix: "" });
 
 /**
+ * Hosts that serve NotebookLM.
+ *
+ * Google rebranded NotebookLM to "Gemini Notebook" on 2026-07-16 and now
+ * 302-redirects notebooklm.google.com -> notebook.google.com. Both are
+ * accepted so this keeps working whichever host the browser lands on.
+ */
+export const NOTEBOOKLM_HOSTS = ["notebook.google.com", "notebooklm.google.com"] as const;
+
+/**
+ * True when `url` points at NotebookLM on any of its known hosts.
+ * Compares the parsed hostname so a lookalike host such as
+ * notebook.google.com.evil.test cannot match.
+ */
+export function isNotebookLmUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" &&
+      (NOTEBOOKLM_HOSTS as readonly string[]).includes(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Google NotebookLM Auth URL (used by setup_auth)
  * This is the base Google login URL that redirects to NotebookLM
  */
 export const NOTEBOOKLM_AUTH_URL =
-  "https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fnotebooklm.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin";
+  "https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fnotebook.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin";
 
 export interface Config {
   // NotebookLM - optional, used for legacy default notebook


### PR DESCRIPTION
Fixes #76
Fixes #83

## Problem

Google rebranded NotebookLM to "Gemini Notebook" on 2026-07-16 and now 302-redirects `notebooklm.google.com` to `notebook.google.com`:

```
$ curl -sI -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://notebooklm.google.com/
302 -> https://notebook.google.com/
```

Every login check in `auth-manager.ts` is a hardcoded string match against the old host, so after a successful sign-in the browser sits on `notebook.google.com` and none of the checks ever fire. `setup_auth` spins for its full 10 minutes and returns `Authentication failed or was cancelled` even though the user is logged in. The same applies to `waitForRedirectAfterLogin()` and `waitForNotebook()` on the credential path.

This makes the server unusable for any new install: there is no way to complete first-time auth.

## Fix

Adds `isNotebookLmUrl()` to `config.ts` and routes the 5 hardcoded checks in `auth-manager.ts` through it. `NOTEBOOKLM_AUTH_URL`'s `continue=` now points at the new host.

The helper accepts **both** hosts, so this keeps working whichever one the browser lands on — no follow-up patch needed if Google reverts, and no breakage if they retire the old host later.

```ts
export const NOTEBOOKLM_HOSTS = ["notebook.google.com", "notebooklm.google.com"] as const;

export function isNotebookLmUrl(url: string): boolean {
  try {
    const parsed = new URL(url);
    return (
      parsed.protocol === "https:" &&
      (NOTEBOOKLM_HOSTS as readonly string[]).includes(parsed.hostname)
    );
  } catch {
    return false;
  }
}
```

It parses the URL and compares `hostname` rather than doing a substring match. A naive `includes("notebook.google.com")` would also accept `https://notebook.google.com.evil.test/` and `https://evil.test/?next=https://notebook.google.com/` — both are page-controlled navigation targets, so treating them as "login succeeded" would persist cookies from an attacker-controlled page. Requiring `https:` closes the same hole over plaintext.

## Verification

Ran a table of cases against the built helper:

| URL | Expected | Result |
|---|---|---|
| `https://notebook.google.com/` | true | PASS |
| `https://notebook.google.com/notebook/abc-123` | true | PASS |
| `https://notebooklm.google.com/` | true | PASS |
| `https://notebooklm.google.com/notebook/abc-123` | true | PASS |
| `https://accounts.google.com/v3/signin/identifier` | false | PASS |
| `https://notebook.google.com.evil.test/` | false | PASS |
| `https://evil.test/?x=https://notebook.google.com/` | false | PASS |
| `http://notebook.google.com/` | false | PASS |
| `not-a-url` | false | PASS |
| `` (empty) | false | PASS |

End-to-end on macOS 15 / Node 22 / Chrome 151, against a real Google account:

```
✅ Login successful! NotebookLM URL detected.
✅ Current URL: https://notebook.google.com/?pli=1
✅ Browser state saved (incl. sessionStorage: 0 entries)
✅ Setup complete - authentication saved
✅ [TOOL] setup_auth completed (45.5s)
```

That `Current URL` is exactly the URL the old check could never match. A subsequent headless start returns `"authenticated": true` from `get_health`.

## Notes

- Only auth-path URL checks are touched. The remaining `notebooklm.google.com` strings are tool-description text and a comment in `selectors.ts`; they are documentation, not behavior, so I left them alone to keep the diff reviewable. Happy to update them in this PR if you'd prefer.
- `selectors.ts` still carries its "last verified 2026-05" DOM selectors. This PR does not attempt to re-verify them against the rebranded UI — it only restores the ability to authenticate.
